### PR TITLE
Sonar: Adicionado Github Actions para fazer analise de código do projeto

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,20 @@
+name: Build
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  sonarcloud:
+    name: SonarCloud
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,12 @@
+sonar.projectKey=Zoren-Software_VoleiClub
+sonar.organization=zoren-software
+
+# This is the name and version displayed in the SonarCloud UI.
+#sonar.projectName=VoleiClub
+#sonar.projectVersion=1.0
+
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
+#sonar.sources=.
+
+# Encoding of the source code. Default is default system encoding
+#sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
### O que?

Adicionado configuração para que o Sonar faça o track do código a partir de uma PR ou diretamente da criação de uma branch no projeto

### Por quê?

Para facilitar o desenvolvimento e trazer agilidade no momento de codificar, fazer toda a analise sem precisar fazer o pull request sem ele estar devidamente pronto.

### Como?

Foi seguido os exemplos de configuração sitados na própria documentação do Sonarcloud.io