### PR TITLE
Sistema: Criando funções delete para módulos no sistema - VLC-20

### DIFF
--- a/app/GraphQL/Mutations/FundamentalMutation.php
+++ b/app/GraphQL/Mutations/FundamentalMutation.php
@@ -45,9 +45,12 @@ final class FundamentalMutation
      */
     public function delete($rootValue, array $args, GraphQLContext $context)
     {
+        $fundamental = [];
         foreach ($args['id'] as $id) {
-            $this->fundamental->find($id);
-            $this->fundamental->delete();
+            $this->fundamental = $this->fundamental->deleteFundamental($id);
+            $fundamental[] = $this->fundamental;
         }
+
+        return $fundamental;
     }
 }

--- a/app/GraphQL/Mutations/FundamentalMutation.php
+++ b/app/GraphQL/Mutations/FundamentalMutation.php
@@ -38,4 +38,16 @@ final class FundamentalMutation
 
         return $this->fundamental;
     }
+
+    /**
+     * @param  null  $_
+     * @param  array<string, mixed>  $args
+     */
+    public function delete($rootValue, array $args, GraphQLContext $context)
+    {
+        foreach ($args['id'] as $id) {
+            $this->fundamental->find($id);
+            $this->fundamental->delete();
+        }
+    }
 }

--- a/app/GraphQL/Mutations/PositionMutation.php
+++ b/app/GraphQL/Mutations/PositionMutation.php
@@ -47,9 +47,12 @@ final class PositionMutation
      */
     public function delete($rootValue, array $args, GraphQLContext $context)
     {
+        $positions = [];
         foreach ($args['id'] as $id) {
-            $this->position->find($id);
-            $this->position->delete();
+            $this->position = $this->position->deletePosition($id);
+            $positions[] = $this->position;
         }
+
+        return $positions;
     }
 }

--- a/app/GraphQL/Mutations/PositionMutation.php
+++ b/app/GraphQL/Mutations/PositionMutation.php
@@ -40,4 +40,16 @@ final class PositionMutation
 
         return $this->position;
     }
+
+    /**
+     * @param  null  $_
+     * @param  array<string, mixed>  $args
+     */
+    public function delete($rootValue, array $args, GraphQLContext $context)
+    {
+        foreach ($args['id'] as $id) {
+            $this->position->find($id);
+            $this->position->delete();
+        }
+    }
 }

--- a/app/GraphQL/Mutations/SpecificFundamentalMutation.php
+++ b/app/GraphQL/Mutations/SpecificFundamentalMutation.php
@@ -55,9 +55,12 @@ final class SpecificFundamentalMutation
      */
     public function delete($rootValue, array $args, GraphQLContext $context)
     {
+        $specificFundamentals = [];
         foreach ($args['id'] as $id) {
-            $this->specificFundamental->find($id);
-            $this->specificFundamental->delete();
+            $this->specificFundamental = $this->specificFundamental->deleteSpecificFundamental($id);
+            $specificFundamentals[] = $this->specificFundamental;
         }
+
+        return $specificFundamentals;
     }
 }

--- a/app/GraphQL/Mutations/SpecificFundamentalMutation.php
+++ b/app/GraphQL/Mutations/SpecificFundamentalMutation.php
@@ -48,4 +48,16 @@ final class SpecificFundamentalMutation
 
         return $this->specificFundamental;
     }
+
+    /**
+     * @param  null  $_
+     * @param  array<string, mixed>  $args
+     */
+    public function delete($rootValue, array $args, GraphQLContext $context)
+    {
+        foreach ($args['id'] as $id) {
+            $this->specificFundamental->find($id);
+            $this->specificFundamental->delete();
+        }
+    }
 }

--- a/app/GraphQL/Mutations/TeamMutation.php
+++ b/app/GraphQL/Mutations/TeamMutation.php
@@ -45,9 +45,12 @@ final class TeamMutation
      */
     public function delete($rootValue, array $args, GraphQLContext $context)
     {
+        $teams = [];
         foreach ($args['id'] as $id) {
-            $this->team->find($id);
-            $this->team->delete();
+            $this->team = $this->team->deleteTeam($id);
+            $teams[] = $this->team;
         }
+
+        return $teams;
     }
 }

--- a/app/GraphQL/Mutations/TeamMutation.php
+++ b/app/GraphQL/Mutations/TeamMutation.php
@@ -38,4 +38,16 @@ final class TeamMutation
 
         return $this->team;
     }
+
+    /**
+     * @param  null  $_
+     * @param  array<string, mixed>  $args
+     */
+    public function delete($rootValue, array $args, GraphQLContext $context)
+    {
+        foreach ($args['id'] as $id) {
+            $this->team->find($id);
+            $this->team->delete();
+        }
+    }
 }

--- a/app/GraphQL/Mutations/UserMutation.php
+++ b/app/GraphQL/Mutations/UserMutation.php
@@ -51,7 +51,9 @@ final class UserMutation
      */
     public function delete($rootValue, array $args, GraphQLContext $context)
     {
-        $this->user->findOrFail($args['id']);
-        $this->user->delete();
+        foreach ($args['id'] as $id) {
+            $this->user->findOrFail($id);
+            $this->user->delete();
+        }
     }
 }

--- a/app/GraphQL/Mutations/UserMutation.php
+++ b/app/GraphQL/Mutations/UserMutation.php
@@ -53,9 +53,8 @@ final class UserMutation
     {
         $users = [];
         foreach ($args['id'] as $id) {
-            $this->user = $this->user->findOrFail($id);
+            $this->user = $this->user->deleteUser($id);
             $users[] = $this->user;
-            $this->user->delete();
         }
 
         return $users;

--- a/app/GraphQL/Mutations/UserMutation.php
+++ b/app/GraphQL/Mutations/UserMutation.php
@@ -44,4 +44,14 @@ final class UserMutation
 
         return $this->user;
     }
+
+    /**
+     * @param  null  $_
+     * @param  array<string, mixed>  $args
+     */
+    public function delete($rootValue, array $args, GraphQLContext $context)
+    {
+        $this->user->findOrFail($args['id']);
+        $this->user->delete();
+    }
 }

--- a/app/GraphQL/Mutations/UserMutation.php
+++ b/app/GraphQL/Mutations/UserMutation.php
@@ -51,9 +51,13 @@ final class UserMutation
      */
     public function delete($rootValue, array $args, GraphQLContext $context)
     {
+        $users = [];
         foreach ($args['id'] as $id) {
-            $this->user->findOrFail($id);
+            $this->user = $this->user->findOrFail($id);
+            $users[] = $this->user;
             $this->user->delete();
         }
+
+        return $users;
     }
 }

--- a/app/Models/Fundamental.php
+++ b/app/Models/Fundamental.php
@@ -28,4 +28,16 @@ class Fundamental extends Model
     {
         return $this->hasMany(SpecificFundamental::class);
     }
+
+    /**
+     * @codeCoverageIgnore
+     * @return Fundamental
+     */
+    public function deleteFundamental(int $id): Fundamental
+    {
+        $fundamental = $this->findOrFail($id);
+        $fundamental->delete();
+
+        return $fundamental;
+    }
 }

--- a/app/Models/Position.php
+++ b/app/Models/Position.php
@@ -24,4 +24,16 @@ class Position extends Model
         ->withTimestamps()
         ->withPivot('created_at', 'updated_at');
     }
+
+    /**
+     * @codeCoverageIgnore
+     * @return Position
+     */
+    public function deletePosition(int $id): Position
+    {
+        $position = $this->findOrFail($id);
+        $position->delete();
+
+        return $position;
+    }
 }

--- a/app/Models/SpecificFundamental.php
+++ b/app/Models/SpecificFundamental.php
@@ -32,4 +32,16 @@ class SpecificFundamental extends Model
             ->withTimestamps()
             ->withPivot('created_at', 'updated_at');
     }
+
+    /**
+     * @codeCoverageIgnore
+     * @return SpecificFundamental
+     */
+    public function deleteSpecificFundamental(int $id): SpecificFundamental
+    {
+        $specificFundamental = $this->findOrFail($id);
+        $specificFundamental->delete();
+
+        return $specificFundamental;
+    }
 }

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -21,4 +21,16 @@ class Team extends Model
     {
         return $this->belongsTo(User::class);
     }
+
+    /**
+     * @codeCoverageIgnore
+     * @return Team
+     */
+    public function deleteTeam(int $id): Team
+    {
+        $team = $this->findOrFail($id);
+        $team->delete();
+
+        return $team;
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Facades\Hash;
@@ -19,6 +20,8 @@ class User extends Authenticatable implements HasApiTokensContract
     use Notifiable;
 
     use HasRoles;
+
+    use SoftDeletes;
 
     /**
      * The attributes that are mass assignable.

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -77,4 +77,16 @@ class User extends Authenticatable implements HasApiTokensContract
     {
         return $this->hasPermissionsViaRoles($namePermission, auth()->user()->getPermissionsViaRoles()->pluck('name')->toArray());
     }
+
+    /**
+     * @codeCoverageIgnore
+     * @return User
+     */
+    public function deleteUser(int $id): User
+    {
+        $user = $this->findOrFail($id);
+        $user->delete();
+
+        return $user;
+    }
 }

--- a/app/Policies/FundamentalPolicy.php
+++ b/app/Policies/FundamentalPolicy.php
@@ -18,4 +18,9 @@ class FundamentalPolicy
     {
         return $user->hasPermissionTo('edit-fundamental');
     }
+
+    public function delete(User $user): bool
+    {
+        return $user->hasPermissionTo('delete-fundamental');
+    }
 }

--- a/app/Policies/PositionPolicy.php
+++ b/app/Policies/PositionPolicy.php
@@ -23,4 +23,9 @@ class PositionPolicy
     {
         return $user->hasPermissionTo('edit-position');
     }
+
+    public function delete(User $user): bool
+    {
+        return $user->hasPermissionTo('delete-position');
+    }
 }

--- a/app/Policies/SpecificFundamentalPolicy.php
+++ b/app/Policies/SpecificFundamentalPolicy.php
@@ -18,4 +18,9 @@ class SpecificFundamentalPolicy
     {
         return $user->hasPermissionTo('edit-specific-fundamental');
     }
+
+    public function delete(User $user): bool
+    {
+        return $user->hasPermissionTo('delete-specific-fundamental');
+    }
 }

--- a/app/Policies/TeamPolicy.php
+++ b/app/Policies/TeamPolicy.php
@@ -18,4 +18,9 @@ class TeamPolicy
     {
         return $user->hasPermissionTo('edit-team');
     }
+
+    public function delete(User $user): bool
+    {
+        return $user->hasPermissionTo('delete-team');
+    }
 }

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -9,16 +9,6 @@ class UserPolicy
 {
     use HandlesAuthorization;
 
-    /**
-     * Create a new policy instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        //
-    }
-
     public function create(User $user): bool
     {
         return $user->hasPermissionTo('create-user');
@@ -27,5 +17,10 @@ class UserPolicy
     public function edit(User $user): bool
     {
         return $user->hasPermissionTo('edit-user');
+    }
+
+    public function delete(User $user): bool
+    {
+        return $user->hasPermissionTo('delete-user');
     }
 }

--- a/database/migrations/tenant/base/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/tenant/base/2014_10_12_000000_create_users_table.php
@@ -20,6 +20,7 @@ return new class () extends Migration {
             $table->string('password');
             $table->rememberToken();
             $table->timestamps();
+            $table->softDeletes();
         });
     }
 

--- a/database/seeders/tenants/PermissionTableSeeder.php
+++ b/database/seeders/tenants/PermissionTableSeeder.php
@@ -34,31 +34,27 @@ class PermissionTableSeeder extends Seeder
         $user[] = Permission::updateOrCreate(['id' => 2], ['name' => 'edit-user']);
         $user[] = Permission::updateOrCreate(['id' => 3], ['name' => 'list-user']);
         $user[] = Permission::updateOrCreate(['id' => 4], ['name' => 'list-users']);
+        $user[] = Permission::updateOrCreate(['id' => 5], ['name' => 'delete-user']);
 
         $this->sync($technician, $user);
 
         /**
          * Permissões Time
          */
-        $team[] = Permission::updateOrCreate(['id' => 5], ['name' => 'create-team']);
-        $team[] = Permission::updateOrCreate(['id' => 6], ['name' => 'edit-team']);
-        $team[] = Permission::updateOrCreate(['id' => 7], ['name' => 'list-team']);
-        $team[] = Permission::updateOrCreate(['id' => 8], ['name' => 'list-teams']);
-
-        /**
-         * Permissões de Configurações
-         */
-        Permission::updateOrCreate(['id' => 9], ['name' => 'list-role-administrador']);
-        $config[] = Permission::updateOrCreate(['id' => 10], ['name' => 'list-role-technician']);
-        $config[] = Permission::updateOrCreate(['id' => 11], ['name' => 'list-role-player']);
+        $team[] = Permission::updateOrCreate(['id' => 6], ['name' => 'create-team']);
+        $team[] = Permission::updateOrCreate(['id' => 7], ['name' => 'edit-team']);
+        $team[] = Permission::updateOrCreate(['id' => 8], ['name' => 'list-team']);
+        $team[] = Permission::updateOrCreate(['id' => 9], ['name' => 'list-teams']);
+        $team[] = Permission::updateOrCreate(['id' => 10], ['name' => 'delete-team']);
 
         /**
          * Permissões de Fundamentos
          */
-        $fundamental[] = Permission::updateOrCreate(['id' => 12], ['name' => 'create-fundamental']);
-        $fundamental[] = Permission::updateOrCreate(['id' => 13], ['name' => 'edit-fundamental']);
-        $fundamental[] = Permission::updateOrCreate(['id' => 14], ['name' => 'list-fundamental']);
-        $fundamental[] = Permission::updateOrCreate(['id' => 15], ['name' => 'list-fundamentals']);
+        $fundamental[] = Permission::updateOrCreate(['id' => 11], ['name' => 'create-fundamental']);
+        $fundamental[] = Permission::updateOrCreate(['id' => 12], ['name' => 'edit-fundamental']);
+        $fundamental[] = Permission::updateOrCreate(['id' => 13], ['name' => 'list-fundamental']);
+        $fundamental[] = Permission::updateOrCreate(['id' => 14], ['name' => 'list-fundamentals']);
+        $fundamental[] = Permission::updateOrCreate(['id' => 15], ['name' => 'delete-fundamental']);
 
         /**
          * Permissões de Fundamentos Especificos
@@ -67,14 +63,23 @@ class PermissionTableSeeder extends Seeder
         $fundamental[] = Permission::updateOrCreate(['id' => 17], ['name' => 'edit-specific-fundamental']);
         $fundamental[] = Permission::updateOrCreate(['id' => 18], ['name' => 'list-specific-fundamental']);
         $fundamental[] = Permission::updateOrCreate(['id' => 19], ['name' => 'list-specifics-fundamental']);
+        $fundamental[] = Permission::updateOrCreate(['id' => 20], ['name' => 'delete-specific-fundamental']);
 
         /**
          * Permissões de Fundamentos Especificos
          */
-        $position[] = Permission::updateOrCreate(['id' => 20], ['name' => 'create-position']);
-        $position[] = Permission::updateOrCreate(['id' => 21], ['name' => 'edit-position']);
-        $position[] = Permission::updateOrCreate(['id' => 22], ['name' => 'list-position']);
-        $position[] = Permission::updateOrCreate(['id' => 23], ['name' => 'list-positions']);
+        $position[] = Permission::updateOrCreate(['id' => 21], ['name' => 'create-position']);
+        $position[] = Permission::updateOrCreate(['id' => 22], ['name' => 'edit-position']);
+        $position[] = Permission::updateOrCreate(['id' => 23], ['name' => 'list-position']);
+        $position[] = Permission::updateOrCreate(['id' => 24], ['name' => 'list-positions']);
+        $position[] = Permission::updateOrCreate(['id' => 25], ['name' => 'delete-position']);
+
+        /**
+         * Permissões de Configurações
+         */
+        Permission::updateOrCreate(['id' => 26], ['name' => 'list-role-administrador']);
+        $config[] = Permission::updateOrCreate(['id' => 27], ['name' => 'list-role-technician']);
+        $config[] = Permission::updateOrCreate(['id' => 28], ['name' => 'list-role-player']);
 
         /**
          * Relacionando Permissões

--- a/graphql/fundamental/FundamentalMutation.graphql
+++ b/graphql/fundamental/FundamentalMutation.graphql
@@ -17,7 +17,7 @@ extend type Mutation @guard {
         @validator
         @can(ability: "edit")
 
-    fundamentalDelete(id: [ID!]!): Fundamental
+    fundamentalDelete(id: [ID!]!): [Fundamental]
         @field(resolver: "FundamentalMutation@delete")
         @can(ability: "delete")
 }

--- a/graphql/fundamental/FundamentalMutation.graphql
+++ b/graphql/fundamental/FundamentalMutation.graphql
@@ -4,16 +4,20 @@ extend type Mutation @guard {
         name: String!
         userId: Int! @rename(attribute: "user_id") 
     ): Fundamental
-    @field(resolver: "FundamentalMutation@create") 
-    @validator
-    @can(ability: "create")
+        @field(resolver: "FundamentalMutation@create") 
+        @validator
+        @can(ability: "create")
 
     fundamentalEdit(
         id: Int!
         name: String!
         userId: Int! @rename(attribute: "user_id") 
     ): Fundamental
-    @field(resolver: "FundamentalMutation@edit") 
-    @validator
-    @can(ability: "edit")
+        @field(resolver: "FundamentalMutation@edit") 
+        @validator
+        @can(ability: "edit")
+
+    fundamentalDelete(id: [ID!]!): Fundamental
+        @field(resolver: "FundamentalMutation@delete")
+        @can(ability: "delete")
 }

--- a/graphql/position/PositionMutation.graphql
+++ b/graphql/position/PositionMutation.graphql
@@ -1,5 +1,5 @@
 
-extend type Mutation @guard{
+extend type Mutation @guard {
     positionCreate(
         name: String!
         userId: Int! @rename(attribute: "user_id")
@@ -17,7 +17,7 @@ extend type Mutation @guard{
         @validator
         @can(ability: "edit")
 
-    positionDelete(id: [ID!]!): Position
+    positionDelete(id: [ID!]!): [Position]
         @field(resolver: "PositionMutation@delete")
         @can(ability: "delete")
 }

--- a/graphql/position/PositionMutation.graphql
+++ b/graphql/position/PositionMutation.graphql
@@ -4,16 +4,20 @@ extend type Mutation @guard{
         name: String!
         userId: Int! @rename(attribute: "user_id")
     ): Position
-    @field(resolver: "PositionMutation@create") 
-    @validator
-    @can(ability: "create")
+        @field(resolver: "PositionMutation@create") 
+        @validator
+        @can(ability: "create")
 
     positionEdit(
         id: Int!
         name: String!
         userId: Int! @rename(attribute: "user_id") 
     ): Position
-    @field(resolver: "PositionMutation@edit")
-    @validator
-    @can(ability: "edit")
+        @field(resolver: "PositionMutation@edit")
+        @validator
+        @can(ability: "edit")
+
+    positionDelete(id: [ID!]!): Position
+        @field(resolver: "PositionMutation@delete")
+        @can(ability: "delete")
 }

--- a/graphql/specific-fundamental/SpecificFundamentalMutation.graphql
+++ b/graphql/specific-fundamental/SpecificFundamentalMutation.graphql
@@ -5,9 +5,9 @@ extend type Mutation @guard{
         userId: Int! @rename(attribute: "user_id")
         fundamentalId: [Int] @rename(attribute: "fundamental_id")
     ): SpecificFundamental
-    @field(resolver: "SpecificFundamentalMutation@create") 
-    @validator
-    @can(ability: "create")
+        @field(resolver: "SpecificFundamentalMutation@create") 
+        @validator
+        @can(ability: "create")
 
     specificFundamentalEdit(
         id: Int!
@@ -15,7 +15,11 @@ extend type Mutation @guard{
         userId: Int! @rename(attribute: "user_id") 
         fundamentalId: [Int] @rename(attribute: "fundamental_id")
     ): SpecificFundamental
-    @field(resolver: "SpecificFundamentalMutation@edit")
-    @validator
-    @can(ability: "edit")
+        @field(resolver: "SpecificFundamentalMutation@edit")
+        @validator
+        @can(ability: "edit")
+
+    specificFundamentalDelete(id: [ID!]!): SpecificFundamental
+        @field(resolver: "SpecificFundamentalMutation@delete")
+        @can(ability: "delete")
 }

--- a/graphql/specific-fundamental/SpecificFundamentalMutation.graphql
+++ b/graphql/specific-fundamental/SpecificFundamentalMutation.graphql
@@ -1,5 +1,5 @@
 
-extend type Mutation @guard{
+extend type Mutation @guard {
     specificFundamentalCreate(
         name: String!
         userId: Int! @rename(attribute: "user_id")
@@ -19,7 +19,7 @@ extend type Mutation @guard{
         @validator
         @can(ability: "edit")
 
-    specificFundamentalDelete(id: [ID!]!): SpecificFundamental
+    specificFundamentalDelete(id: [ID!]!): [SpecificFundamental]
         @field(resolver: "SpecificFundamentalMutation@delete")
         @can(ability: "delete")
 }

--- a/graphql/team/TeamMutation.graphql
+++ b/graphql/team/TeamMutation.graphql
@@ -4,16 +4,20 @@ extend type Mutation @guard {
         name: String!
         userId: Int! @rename(attribute: "user_id") 
     ): Team
-    @field(resolver: "TeamMutation@create") 
-    @validator
-    @can(ability: "create")
+        @field(resolver: "TeamMutation@create") 
+        @validator
+        @can(ability: "create") 
 
     teamEdit(
         id: Int!
         name: String!
         userId: Int! @rename(attribute: "user_id") 
     ): Team
-    @field(resolver: "TeamMutation@edit") 
-    @validator
-    @can(ability: "edit")
+        @field(resolver: "TeamMutation@edit") 
+        @validator
+        @can(ability: "edit")
+
+    teamDelete(id: [ID!]!): Team
+        @field(resolver: "TeamMutation@delete")
+        @can(ability: "delete")
 }

--- a/graphql/team/TeamMutation.graphql
+++ b/graphql/team/TeamMutation.graphql
@@ -17,7 +17,7 @@ extend type Mutation @guard {
         @validator
         @can(ability: "edit")
 
-    teamDelete(id: [ID!]!): Team
+    teamDelete(id: [ID!]!): [Team]
         @field(resolver: "TeamMutation@delete")
         @can(ability: "delete")
 }

--- a/graphql/user/UserMutation.graphql
+++ b/graphql/user/UserMutation.graphql
@@ -7,9 +7,9 @@ extend type Mutation {
         positionId: [Int]
         password: String! @rules(apply: ["min:6"])
     ): User
-    @field(resolver: "UserMutation@create")
-    @validator
-    @can(ability: "create")
+        @field(resolver: "UserMutation@create")
+        @validator
+        @can(ability: "create")
 
     userEdit(
         id: ID!
@@ -19,7 +19,12 @@ extend type Mutation {
         positionId: [Int]
         password: String! @rules(apply: ["min:6"])
     ): User
-    @field(resolver: "UserMutation@edit")
-    @validator
-    @can(ability: "edit")
+        @field(resolver: "UserMutation@edit")
+        @validator
+        @can(ability: "edit")
+
+    userDelete(id: ID!): User
+        @field(resolver: "UserMutation@delete")
+        @validator
+        @can(ability: "delete")
 }

--- a/graphql/user/UserMutation.graphql
+++ b/graphql/user/UserMutation.graphql
@@ -1,5 +1,5 @@
 
-extend type Mutation {
+extend type Mutation @guard {
     userCreate(
         name: String!
         email: String! @rules(apply: ["email", "unique:users"])

--- a/graphql/user/UserMutation.graphql
+++ b/graphql/user/UserMutation.graphql
@@ -25,5 +25,5 @@ extend type Mutation {
 
     userDelete(id: [ID!]!): [User]
         @field(resolver: "UserMutation@delete")
-        # @can(ability: "delete")
+        @can(ability: "delete")
 }

--- a/graphql/user/UserMutation.graphql
+++ b/graphql/user/UserMutation.graphql
@@ -23,7 +23,7 @@ extend type Mutation {
         @validator
         @can(ability: "edit")
 
-    userDelete(id: [ID!]!): User
+    userDelete(id: [ID!]!): [User]
         @field(resolver: "UserMutation@delete")
-        @can(ability: "delete")
+        # @can(ability: "delete")
 }

--- a/graphql/user/UserMutation.graphql
+++ b/graphql/user/UserMutation.graphql
@@ -23,8 +23,7 @@ extend type Mutation {
         @validator
         @can(ability: "edit")
 
-    userDelete(id: ID!): User
+    userDelete(id: [ID!]!): User
         @field(resolver: "UserMutation@delete")
-        @validator
         @can(ability: "delete")
 }

--- a/graphql/user/UserMutation.graphql
+++ b/graphql/user/UserMutation.graphql
@@ -22,7 +22,7 @@ extend type Mutation @guard {
         @field(resolver: "UserMutation@edit")
         @validator
         @can(ability: "edit")
-
+    
     userDelete(id: [ID!]!): [User]
         @field(resolver: "UserMutation@delete")
         @can(ability: "delete")

--- a/tests/Feature/GraphQL/FundamentalTest.php
+++ b/tests/Feature/GraphQL/FundamentalTest.php
@@ -250,7 +250,7 @@ class FundamentalTest extends TestCase
                     'userId' => $userId,
                 ],
                 'type_message_error' => 'message',
-                'expected_message' => 'This action is unauthorized.',
+                'expected_message' => $this->unauthorized,
                 'expected' => [
                     'errors' => $this->errors,
                     'data' => $fundamentalEdit

--- a/tests/Feature/GraphQL/PositionTest.php
+++ b/tests/Feature/GraphQL/PositionTest.php
@@ -250,7 +250,7 @@ class PositionTest extends TestCase
                     'userId' => $userId,
                 ],
                 'type_message_error' => 'message',
-                'expected_message' => 'This action is unauthorized.',
+                'expected_message' => $this->unauthorized,
                 'expected' => [
                     'errors' => $this->errors,
                     'data' => $positionEdit

--- a/tests/Feature/GraphQL/SpecificFundamentalTest.php
+++ b/tests/Feature/GraphQL/SpecificFundamentalTest.php
@@ -285,7 +285,7 @@ class SpecificFundamentalTest extends TestCase
                     'userId' => $userId,
                 ],
                 'type_message_error' => 'message',
-                'expected_message' => 'This action is unauthorized.',
+                'expected_message' => $this->unauthorized,
                 'expected' => [
                     'errors' => $this->errors,
                     'data' => $fundamentalEdit

--- a/tests/Feature/GraphQL/TeamTest.php
+++ b/tests/Feature/GraphQL/TeamTest.php
@@ -252,7 +252,7 @@ class TeamTest extends TestCase
                     'userId' => $userId,
                 ],
                 'type_message_error' => 'message',
-                'expected_message' => 'This action is unauthorized.',
+                'expected_message' => $this->unauthorized,
                 'expected' => [
                     'errors' => $this->errors,
                     'data' => $teamEdit

--- a/tests/Feature/GraphQL/UserTest.php
+++ b/tests/Feature/GraphQL/UserTest.php
@@ -14,6 +14,8 @@ class UserTest extends TestCase
 
     protected $otherUser = false;
 
+    private $permission = 'Técnico';
+
     private $data = [
         'id',
         'name',
@@ -104,7 +106,7 @@ class UserTest extends TestCase
 
         $faker = Faker::create();
 
-        $this->checkPermission($permission, 'Técnico', 'create-user');
+        $this->checkPermission($permission, $this->permission, 'create-user');
 
         $parameters['name'] = $faker->name;
 
@@ -208,7 +210,7 @@ class UserTest extends TestCase
                     'password' => $password,
                 ],
                 'type_message_error' => 'message',
-                'expected_message' => 'This action is unauthorized.',
+                'expected_message' => $this->unauthorized,
                 'expected' => [
                     'errors' => $this->errors,
                     'data' => $userCreate
@@ -320,7 +322,7 @@ class UserTest extends TestCase
     {
         $this->login = true;
 
-        $this->checkPermission($permission, 'Técnico', 'edit-user');
+        $this->checkPermission($permission, $this->permission, 'edit-user');
 
         $userExist = User::factory()->make();
         $userExist->save();
@@ -407,7 +409,7 @@ class UserTest extends TestCase
                     'roleId' => [2],
                 ],
                 'type_message_error' => 'message',
-                'expected_message' => 'This action is unauthorized.',
+                'expected_message' => $this->unauthorized,
                 'expected' => [
                     'errors' => $this->errors,
                     'data' => $userEdit
@@ -551,7 +553,7 @@ class UserTest extends TestCase
     {
         $this->login = true;
 
-        $this->checkPermission($permission, 'Técnico', 'delete-user');
+        $this->checkPermission($permission, $this->permission, 'delete-user');
 
         $user = User::factory()->make();
         $user->save();
@@ -596,8 +598,6 @@ class UserTest extends TestCase
      */
     public function userDeleteProvider()
     {
-        $faker = Faker::create();
-
         $userDelete = ['userDelete'];
 
         return [
@@ -613,7 +613,7 @@ class UserTest extends TestCase
             'delete user without permission, expected error' => [
                 ['error' => null],
                 'type_message_error' => 'message',
-                'expected_message' => 'This action is unauthorized.',
+                'expected_message' => $this->unauthorized,
                 'expected' => [
                     'errors' => $this->errors,
                     'data' => $userDelete

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -280,7 +280,11 @@ abstract class TestCase extends BaseTestCase
             if (!$permission) {
                 $this->assertSame($response->json()['errors'][0][$type_message_error], $expected_message);
             } else {
-                $this->assertSame($response->json()['errors'][0]['extensions']['validation'][$type_message_error][0], trans($expected_message));
+                if (isset($response->json()['errors'][0]['extensions']['validation'])) {
+                    $this->assertSame($response->json()['errors'][0]['extensions']['validation'][$type_message_error][0], trans($expected_message));
+                } else {
+                    $this->assertSame($response->json()['errors'][0]['extensions']['category'], trans($expected_message));
+                }
             }
         }
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -53,6 +53,8 @@ abstract class TestCase extends BaseTestCase
         ]
     ];
 
+    protected $unauthorized = 'This action is unauthorized.';
+
     public $tenantUrl;
 
     public function setUp(): void
@@ -287,5 +289,17 @@ abstract class TestCase extends BaseTestCase
                 }
             }
         }
+    }
+
+    public function permissionProvider(): array
+    {
+        return [
+            'when permission allows' => [
+                true,
+            ],
+            'when permission does not allow' => [
+                false
+            ],
+        ];
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -282,10 +282,14 @@ abstract class TestCase extends BaseTestCase
             if (!$permission) {
                 $this->assertSame($response->json()['errors'][0][$type_message_error], $expected_message);
             } else {
-                if (isset($response->json()['errors'][0]['extensions']['validation'])) {
-                    $this->assertSame($response->json()['errors'][0]['extensions']['validation'][$type_message_error][0], trans($expected_message));
+                if (isset($response->json()['errors'][0]['extensions'])) {
+                    $response = $response->json()['errors'][0]['extensions'];
+                }
+
+                if (isset($response['validation'])) {
+                    $this->assertSame($response['validation'][$type_message_error][0], trans($expected_message));
                 } else {
-                    $this->assertSame($response->json()['errors'][0]['extensions']['category'], trans($expected_message));
+                    $this->assertSame($response['category'], trans($expected_message));
                 }
             }
         }

--- a/tests/Unit/App/GraphQL/Mutations/FundamentalMutationTest.php
+++ b/tests/Unit/App/GraphQL/Mutations/FundamentalMutationTest.php
@@ -50,7 +50,7 @@ class FundamentalMutationTest extends TestCase
         ], $graphQLContext);
     }
 
-        /**
+    /**
      * A basic unit test in delete position.
      * @dataProvider positionDeleteProvider
      *

--- a/tests/Unit/App/GraphQL/Mutations/FundamentalMutationTest.php
+++ b/tests/Unit/App/GraphQL/Mutations/FundamentalMutationTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\GraphQL\Mutations;
+namespace Tests\Unit\App\GraphQL\Mutations;
 
 use App\GraphQL\Mutations\FundamentalMutation;
 use App\Models\Fundamental;

--- a/tests/Unit/App/GraphQL/Mutations/FundamentalMutationTest.php
+++ b/tests/Unit/App/GraphQL/Mutations/FundamentalMutationTest.php
@@ -49,4 +49,49 @@ class FundamentalMutationTest extends TestCase
             'user_id' => 1,
         ], $graphQLContext);
     }
+
+        /**
+     * A basic unit test in delete position.
+     * @dataProvider positionDeleteProvider
+     *
+     * @return void
+     */
+    public function test_fundamental_delete($data, $number, $expected)
+    {
+        $graphQLContext = $this->createMock(GraphQLContext::class);
+        $fundamental = $this->createMock(Fundamental::class);
+
+        $fundamental->expects($this->exactly($number))
+            ->method('delete');
+
+        $fundamentalMutation = new FundamentalMutation($fundamental);
+        $fundamentalMutation->delete(
+            null,
+            [
+                'id' => $data,
+            ],
+            $graphQLContext
+        );
+    }
+
+    public function positionDeleteProvider()
+    {
+        return [
+            'send array, success' => [
+                [1],
+                1,
+                ''
+            ],
+            'send multiple itens in array, success' => [
+                [1, 2, 3],
+                3,
+                ''
+            ],
+            'send empty array, success' => [
+                [],
+                0,
+                ''
+            ]
+        ];
+    }
 }

--- a/tests/Unit/App/GraphQL/Mutations/FundamentalMutationTest.php
+++ b/tests/Unit/App/GraphQL/Mutations/FundamentalMutationTest.php
@@ -56,13 +56,14 @@ class FundamentalMutationTest extends TestCase
      *
      * @return void
      */
-    public function test_fundamental_delete($data, $number, $expected)
+    public function test_fundamental_delete($data, $number)
     {
         $graphQLContext = $this->createMock(GraphQLContext::class);
         $fundamental = $this->createMock(Fundamental::class);
 
         $fundamental->expects($this->exactly($number))
-            ->method('delete');
+            ->method('deleteFundamental')
+            ->willReturn($fundamental);
 
         $fundamentalMutation = new FundamentalMutation($fundamental);
         $fundamentalMutation->delete(
@@ -80,17 +81,14 @@ class FundamentalMutationTest extends TestCase
             'send array, success' => [
                 [1],
                 1,
-                ''
             ],
             'send multiple itens in array, success' => [
                 [1, 2, 3],
                 3,
-                ''
             ],
             'send empty array, success' => [
                 [],
                 0,
-                ''
             ]
         ];
     }

--- a/tests/Unit/App/GraphQL/Mutations/PositionMutationTest.php
+++ b/tests/Unit/App/GraphQL/Mutations/PositionMutationTest.php
@@ -47,4 +47,49 @@ class PositionMutationTest extends TestCase
             'user_id' => 1,
         ], $graphQLContext);
     }
+
+    /**
+     * A basic unit test in delete position.
+     * @dataProvider positionDeleteProvider
+     *
+     * @return void
+     */
+    public function test_position_delete($data, $number, $expected)
+    {
+        $graphQLContext = $this->createMock(GraphQLContext::class);
+        $position = $this->createMock(Position::class);
+
+        $position->expects($this->exactly($number))
+            ->method('delete');
+
+        $positionMutation = new PositionMutation($position);
+        $positionMutation->delete(
+            null,
+            [
+                'id' => $data,
+            ],
+            $graphQLContext
+        );
+    }
+
+    public function positionDeleteProvider()
+    {
+        return [
+            'send array, success' => [
+                [1],
+                1,
+                ''
+            ],
+            'send multiple itens in array, success' => [
+                [1, 2, 3],
+                3,
+                ''
+            ],
+            'send empty array, success' => [
+                [],
+                0,
+                ''
+            ]
+        ];
+    }
 }

--- a/tests/Unit/App/GraphQL/Mutations/PositionMutationTest.php
+++ b/tests/Unit/App/GraphQL/Mutations/PositionMutationTest.php
@@ -54,13 +54,14 @@ class PositionMutationTest extends TestCase
      *
      * @return void
      */
-    public function test_position_delete($data, $number, $expected)
+    public function test_position_delete($data, $number)
     {
         $graphQLContext = $this->createMock(GraphQLContext::class);
         $position = $this->createMock(Position::class);
 
         $position->expects($this->exactly($number))
-            ->method('delete');
+            ->method('deletePosition')
+            ->willReturn($position);
 
         $positionMutation = new PositionMutation($position);
         $positionMutation->delete(
@@ -78,17 +79,14 @@ class PositionMutationTest extends TestCase
             'send array, success' => [
                 [1],
                 1,
-                ''
             ],
             'send multiple itens in array, success' => [
                 [1, 2, 3],
                 3,
-                ''
             ],
             'send empty array, success' => [
                 [],
                 0,
-                ''
             ]
         ];
     }

--- a/tests/Unit/App/GraphQL/Mutations/PositionMutationTest.php
+++ b/tests/Unit/App/GraphQL/Mutations/PositionMutationTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\GraphQL\Mutations;
+namespace Tests\Unit\App\GraphQL\Mutations;
 
 use App\GraphQL\Mutations\PositionMutation;
 use App\Models\Position;

--- a/tests/Unit/App/GraphQL/Mutations/SpecificFundamentalMutationTest.php
+++ b/tests/Unit/App/GraphQL/Mutations/SpecificFundamentalMutationTest.php
@@ -6,7 +6,7 @@ use App\GraphQL\Mutations\SpecificFundamentalMutation;
 use App\Models\Fundamental;
 use App\Models\SpecificFundamental;
 use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 
 class SpecificFundamentalMutationTest extends TestCase
 {
@@ -100,13 +100,14 @@ class SpecificFundamentalMutationTest extends TestCase
      *
      * @return void
      */
-    public function test_specific_fundamental_delete($data, $number, $expected)
+    public function test_specific_fundamental_delete($data, $number)
     {
         $graphQLContext = $this->createMock(GraphQLContext::class);
         $specificFundamental = $this->createMock(SpecificFundamental::class);
 
         $specificFundamental->expects($this->exactly($number))
-            ->method('delete');
+            ->method('deleteSpecificFundamental')
+            ->willReturn($specificFundamental);
 
         $specificFundamentalMutation = new SpecificFundamentalMutation($specificFundamental);
         $specificFundamentalMutation->delete(
@@ -124,17 +125,14 @@ class SpecificFundamentalMutationTest extends TestCase
             'send array, success' => [
                 [1],
                 1,
-                ''
             ],
             'send multiple itens in array, success' => [
                 [1, 2, 3],
                 3,
-                ''
             ],
             'send empty array, success' => [
                 [],
                 0,
-                ''
             ]
         ];
     }

--- a/tests/Unit/App/GraphQL/Mutations/SpecificFundamentalMutationTest.php
+++ b/tests/Unit/App/GraphQL/Mutations/SpecificFundamentalMutationTest.php
@@ -93,4 +93,49 @@ class SpecificFundamentalMutationTest extends TestCase
             ]
         ];
     }
+
+    /**
+     * A basic unit test in delete specificFundamental.
+     * @dataProvider specificFundamentalDeleteProvider
+     *
+     * @return void
+     */
+    public function test_specific_fundamental_delete($data, $number, $expected)
+    {
+        $graphQLContext = $this->createMock(GraphQLContext::class);
+        $specificFundamental = $this->createMock(SpecificFundamental::class);
+
+        $specificFundamental->expects($this->exactly($number))
+            ->method('delete');
+
+        $specificFundamentalMutation = new SpecificFundamentalMutation($specificFundamental);
+        $specificFundamentalMutation->delete(
+            null,
+            [
+                'id' => $data,
+            ],
+            $graphQLContext
+        );
+    }
+
+    public function specificFundamentalDeleteProvider()
+    {
+        return [
+            'send array, success' => [
+                [1],
+                1,
+                ''
+            ],
+            'send multiple itens in array, success' => [
+                [1, 2, 3],
+                3,
+                ''
+            ],
+            'send empty array, success' => [
+                [],
+                0,
+                ''
+            ]
+        ];
+    }
 }

--- a/tests/Unit/App/GraphQL/Mutations/SpecificFundamentalMutationTest.php
+++ b/tests/Unit/App/GraphQL/Mutations/SpecificFundamentalMutationTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\GraphQL\Mutations;
+namespace Tests\Unit\App\GraphQL\Mutations;
 
 use App\GraphQL\Mutations\SpecificFundamentalMutation;
 use App\Models\Fundamental;

--- a/tests/Unit/App/GraphQL/Mutations/TeamMutationTest.php
+++ b/tests/Unit/App/GraphQL/Mutations/TeamMutationTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\GraphQL\Mutations;
+namespace Tests\Unit\App\GraphQL\Mutations;
 
 use App\GraphQL\Mutations\TeamMutation;
 use App\Models\Team;

--- a/tests/Unit/App/GraphQL/Mutations/TeamMutationTest.php
+++ b/tests/Unit/App/GraphQL/Mutations/TeamMutationTest.php
@@ -49,4 +49,49 @@ class TeamMutationTest extends TestCase
             'user_id' => 1,
         ], $graphQLContext);
     }
+
+    /**
+     * A basic unit test in delete team.
+     * @dataProvider teamDeleteProvider
+     *
+     * @return void
+     */
+    public function test_team_delete($data, $number, $expected)
+    {
+        $graphQLContext = $this->createMock(GraphQLContext::class);
+        $team = $this->createMock(Team::class);
+
+        $team->expects($this->exactly($number))
+            ->method('delete');
+
+        $teamMutation = new TeamMutation($team);
+        $teamMutation->delete(
+            null,
+            [
+                'id' => $data,
+            ],
+            $graphQLContext
+        );
+    }
+
+    public function teamDeleteProvider()
+    {
+        return [
+            'send array, success' => [
+                [1],
+                1,
+                ''
+            ],
+            'send multiple itens in array, success' => [
+                [1, 2, 3],
+                3,
+                ''
+            ],
+            'send empty array, success' => [
+                [],
+                0,
+                ''
+            ]
+        ];
+    }
 }

--- a/tests/Unit/App/GraphQL/Mutations/TeamMutationTest.php
+++ b/tests/Unit/App/GraphQL/Mutations/TeamMutationTest.php
@@ -56,13 +56,15 @@ class TeamMutationTest extends TestCase
      *
      * @return void
      */
-    public function test_team_delete($data, $number, $expected)
+    public function test_team_delete($data, $number)
     {
         $graphQLContext = $this->createMock(GraphQLContext::class);
         $team = $this->createMock(Team::class);
 
-        $team->expects($this->exactly($number))
-            ->method('delete');
+        $team
+            ->expects($this->exactly($number))
+            ->method('deleteTeam')
+            ->willReturn($team);
 
         $teamMutation = new TeamMutation($team);
         $teamMutation->delete(
@@ -80,17 +82,14 @@ class TeamMutationTest extends TestCase
             'send array, success' => [
                 [1],
                 1,
-                ''
             ],
             'send multiple itens in array, success' => [
                 [1, 2, 3],
                 3,
-                ''
             ],
             'send empty array, success' => [
                 [],
                 0,
-                ''
             ]
         ];
     }

--- a/tests/Unit/App/GraphQL/Mutations/UserMutationTest.php
+++ b/tests/Unit/App/GraphQL/Mutations/UserMutationTest.php
@@ -103,7 +103,7 @@ class UserMutationTest extends TestCase
      *
      * @return void
      */
-    public function test_user_delete($data, $number, $expected)
+    public function test_user_delete($data, $number)
     {
         $graphQLContext = $this->createMock(GraphQLContext::class);
         $user = $this->createMock(User::class);
@@ -129,17 +129,14 @@ class UserMutationTest extends TestCase
             'send array, success' => [
                 [1],
                 1,
-                ''
             ],
             'send multiple itens in array, success' => [
                 [1, 2, 3],
                 3,
-                ''
             ],
             'send empty array, success' => [
                 [],
                 0,
-                ''
             ]
         ];
     }

--- a/tests/Unit/App/GraphQL/Mutations/UserMutationTest.php
+++ b/tests/Unit/App/GraphQL/Mutations/UserMutationTest.php
@@ -5,7 +5,7 @@ namespace Tests\Unit\App\GraphQL\Mutations;
 use App\GraphQL\Mutations\UserMutation;
 use App\Models\User;
 use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 
 class UserMutationTest extends TestCase
 {
@@ -99,24 +99,46 @@ class UserMutationTest extends TestCase
 
     /**
      * A basic unit test in delete user.
+     * @dataProvider userDeleteProvider
      *
      * @return void
      */
-    public function test_user_delete()
+    public function test_user_delete($data, $number, $expected)
     {
         $graphQLContext = $this->createMock(GraphQLContext::class);
         $user = $this->createMock(User::class);
 
-        $user->expects($this->once())
+        $user->expects($this->exactly($number))
             ->method('delete');
 
         $userMutation = new UserMutation($user);
         $userMutation->delete(
             null,
             [
-                'id' => 1,
+                'id' => $data,
             ],
             $graphQLContext
         );
+    }
+
+    public function userDeleteProvider()
+    {
+        return [
+            'send array, success' => [
+                [1],
+                1,
+                ''
+            ],
+            'send multiple itens in array, success' => [
+                [1, 2, 3],
+                3,
+                ''
+            ],
+            'send empty array, success' => [
+                [],
+                0,
+                ''
+            ]
+        ];
     }
 }

--- a/tests/Unit/App/GraphQL/Mutations/UserMutationTest.php
+++ b/tests/Unit/App/GraphQL/Mutations/UserMutationTest.php
@@ -108,8 +108,10 @@ class UserMutationTest extends TestCase
         $graphQLContext = $this->createMock(GraphQLContext::class);
         $user = $this->createMock(User::class);
 
-        $user->expects($this->exactly($number))
-            ->method('delete');
+        $user
+            ->expects($this->exactly($number))
+            ->method('deleteUser')
+            ->willReturn($user);
 
         $userMutation = new UserMutation($user);
         $userMutation->delete(

--- a/tests/Unit/App/GraphQL/Mutations/UserMutationTest.php
+++ b/tests/Unit/App/GraphQL/Mutations/UserMutationTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\GraphQL\Mutations;
+namespace Tests\Unit\App\GraphQL\Mutations;
 
 use App\GraphQL\Mutations\UserMutation;
 use App\Models\User;

--- a/tests/Unit/App/GraphQL/Mutations/UserMutationTest.php
+++ b/tests/Unit/App/GraphQL/Mutations/UserMutationTest.php
@@ -96,4 +96,27 @@ class UserMutationTest extends TestCase
             ],
         ];
     }
+
+    /**
+     * A basic unit test in delete user.
+     *
+     * @return void
+     */
+    public function test_user_delete()
+    {
+        $graphQLContext = $this->createMock(GraphQLContext::class);
+        $user = $this->createMock(User::class);
+
+        $user->expects($this->once())
+            ->method('delete');
+
+        $userMutation = new UserMutation($user);
+        $userMutation->delete(
+            null,
+            [
+                'id' => 1,
+            ],
+            $graphQLContext
+        );
+    }
 }

--- a/tests/Unit/App/GraphQL/Validators/Mutation/FundamentalCreateValidatorTest.php
+++ b/tests/Unit/App/GraphQL/Validators/Mutation/FundamentalCreateValidatorTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Tests\Unit\GraphQL\Validators\Mutation;
+namespace Tests\Unit\App\GraphQL\Validators\Mutation;
 
-use App\GraphQL\Validators\Mutation\PositionCreateValidator;
+use App\GraphQL\Validators\Mutation\FundamentalCreateValidator;
 use Tests\TestCase;
 
-class PositionCreateValidatorTest extends TestCase
+class FundamentalCreateValidatorTest extends TestCase
 {
     /**
      * A basic unit test messages.
@@ -14,7 +14,7 @@ class PositionCreateValidatorTest extends TestCase
      */
     public function test_messages()
     {
-        $validator = new PositionCreateValidator();
+        $validator = new FundamentalCreateValidator();
 
         $this->assertIsArray($validator->messages());
         $this->assertNotEmpty($validator->messages());

--- a/tests/Unit/App/GraphQL/Validators/Mutation/FundamentalEditValidatorTest.php
+++ b/tests/Unit/App/GraphQL/Validators/Mutation/FundamentalEditValidatorTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Tests\Unit\GraphQL\Validators\Mutation;
+namespace Tests\Unit\App\GraphQL\Validators\Mutation;
 
-use App\GraphQL\Validators\Mutation\TeamEditValidator;
+use App\GraphQL\Validators\Mutation\FundamentalEditValidator;
 use Nuwave\Lighthouse\Execution\Arguments\ArgumentSet;
 use Tests\TestCase;
 
-class TeamEditValidatorTest extends TestCase
+class FundamentalEditValidatorTest extends TestCase
 {
     /**
      * A basic unit test messages.
@@ -15,7 +15,7 @@ class TeamEditValidatorTest extends TestCase
      */
     public function test_messages()
     {
-        $validator = new TeamEditValidator();
+        $validator = new FundamentalEditValidator();
 
         $this->assertIsArray($validator->messages());
         $this->assertNotEmpty($validator->messages());
@@ -31,7 +31,7 @@ class TeamEditValidatorTest extends TestCase
         $args = new ArgumentSet();
         $args->toArray('id');
 
-        $validator = new TeamEditValidator();
+        $validator = new FundamentalEditValidator();
         $validator->setArgs($args);
 
         $this->assertIsArray($validator->rules());

--- a/tests/Unit/App/GraphQL/Validators/Mutation/PositionCreateValidatorTest.php
+++ b/tests/Unit/App/GraphQL/Validators/Mutation/PositionCreateValidatorTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Tests\Unit\GraphQL\Validators\Mutation;
+namespace Tests\Unit\App\GraphQL\Validators\Mutation;
 
-use App\GraphQL\Validators\Mutation\SpecificFundamentalCreateValidator;
+use App\GraphQL\Validators\Mutation\PositionCreateValidator;
 use Tests\TestCase;
 
-class SpecificFundamentalCreateValidatorTest extends TestCase
+class PositionCreateValidatorTest extends TestCase
 {
     /**
      * A basic unit test messages.
@@ -14,7 +14,7 @@ class SpecificFundamentalCreateValidatorTest extends TestCase
      */
     public function test_messages()
     {
-        $validator = new SpecificFundamentalCreateValidator();
+        $validator = new PositionCreateValidator();
 
         $this->assertIsArray($validator->messages());
         $this->assertNotEmpty($validator->messages());

--- a/tests/Unit/App/GraphQL/Validators/Mutation/PositionEditValidatorTest.php
+++ b/tests/Unit/App/GraphQL/Validators/Mutation/PositionEditValidatorTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Tests\Unit\GraphQL\Validators\Mutation;
+namespace Tests\Unit\App\GraphQL\Validators\Mutation;
 
-use App\GraphQL\Validators\Mutation\UserEditValidator;
+use App\GraphQL\Validators\Mutation\PositionEditValidator;
 use Nuwave\Lighthouse\Execution\Arguments\ArgumentSet;
 use Tests\TestCase;
 
-class UserEditValidatorTest extends TestCase
+class PositionEditValidatorTest extends TestCase
 {
     /**
      * A basic unit test messages.
@@ -15,7 +15,7 @@ class UserEditValidatorTest extends TestCase
      */
     public function test_messages()
     {
-        $validator = new UserEditValidator();
+        $validator = new PositionEditValidator();
 
         $this->assertIsArray($validator->messages());
         $this->assertNotEmpty($validator->messages());
@@ -31,7 +31,7 @@ class UserEditValidatorTest extends TestCase
         $args = new ArgumentSet();
         $args->toArray('id');
 
-        $validator = new UserEditValidator();
+        $validator = new PositionEditValidator();
         $validator->setArgs($args);
 
         $this->assertIsArray($validator->rules());

--- a/tests/Unit/App/GraphQL/Validators/Mutation/SpecificFundamentalCreateValidatorTest.php
+++ b/tests/Unit/App/GraphQL/Validators/Mutation/SpecificFundamentalCreateValidatorTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Tests\Unit\GraphQL\Validators\Mutation;
+namespace Tests\Unit\App\GraphQL\Validators\Mutation;
 
-use App\GraphQL\Validators\Mutation\FundamentalCreateValidator;
+use App\GraphQL\Validators\Mutation\SpecificFundamentalCreateValidator;
 use Tests\TestCase;
 
-class FundamentalCreateValidatorTest extends TestCase
+class SpecificFundamentalCreateValidatorTest extends TestCase
 {
     /**
      * A basic unit test messages.
@@ -14,7 +14,7 @@ class FundamentalCreateValidatorTest extends TestCase
      */
     public function test_messages()
     {
-        $validator = new FundamentalCreateValidator();
+        $validator = new SpecificFundamentalCreateValidator();
 
         $this->assertIsArray($validator->messages());
         $this->assertNotEmpty($validator->messages());

--- a/tests/Unit/App/GraphQL/Validators/Mutation/SpecificFundamentalEditValidatorTest.php
+++ b/tests/Unit/App/GraphQL/Validators/Mutation/SpecificFundamentalEditValidatorTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Tests\Unit\GraphQL\Validators\Mutation;
+namespace Tests\Unit\App\GraphQL\Validators\Mutation;
 
-use App\GraphQL\Validators\Mutation\FundamentalEditValidator;
+use App\GraphQL\Validators\Mutation\SpecificFundamentalEditValidator;
 use Nuwave\Lighthouse\Execution\Arguments\ArgumentSet;
 use Tests\TestCase;
 
-class FundamentalEditValidatorTest extends TestCase
+class SpecificFundamentalEditValidatorTest extends TestCase
 {
     /**
      * A basic unit test messages.
@@ -15,7 +15,7 @@ class FundamentalEditValidatorTest extends TestCase
      */
     public function test_messages()
     {
-        $validator = new FundamentalEditValidator();
+        $validator = new SpecificFundamentalEditValidator();
 
         $this->assertIsArray($validator->messages());
         $this->assertNotEmpty($validator->messages());
@@ -31,7 +31,7 @@ class FundamentalEditValidatorTest extends TestCase
         $args = new ArgumentSet();
         $args->toArray('id');
 
-        $validator = new FundamentalEditValidator();
+        $validator = new SpecificFundamentalEditValidator();
         $validator->setArgs($args);
 
         $this->assertIsArray($validator->rules());

--- a/tests/Unit/App/GraphQL/Validators/Mutation/TeamCreateValidatorTest.php
+++ b/tests/Unit/App/GraphQL/Validators/Mutation/TeamCreateValidatorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\GraphQL\Validators\Mutation;
+namespace Tests\Unit\App\GraphQL\Validators\Mutation;
 
 use App\GraphQL\Validators\Mutation\TeamCreateValidator;
 use Tests\TestCase;

--- a/tests/Unit/App/GraphQL/Validators/Mutation/TeamEditValidatorTest.php
+++ b/tests/Unit/App/GraphQL/Validators/Mutation/TeamEditValidatorTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Tests\Unit\GraphQL\Validators\Mutation;
+namespace Tests\Unit\App\GraphQL\Validators\Mutation;
 
-use App\GraphQL\Validators\Mutation\SpecificFundamentalEditValidator;
+use App\GraphQL\Validators\Mutation\TeamEditValidator;
 use Nuwave\Lighthouse\Execution\Arguments\ArgumentSet;
 use Tests\TestCase;
 
-class SpecificFundamentalEditValidatorTest extends TestCase
+class TeamEditValidatorTest extends TestCase
 {
     /**
      * A basic unit test messages.
@@ -15,7 +15,7 @@ class SpecificFundamentalEditValidatorTest extends TestCase
      */
     public function test_messages()
     {
-        $validator = new SpecificFundamentalEditValidator();
+        $validator = new TeamEditValidator();
 
         $this->assertIsArray($validator->messages());
         $this->assertNotEmpty($validator->messages());
@@ -31,7 +31,7 @@ class SpecificFundamentalEditValidatorTest extends TestCase
         $args = new ArgumentSet();
         $args->toArray('id');
 
-        $validator = new SpecificFundamentalEditValidator();
+        $validator = new TeamEditValidator();
         $validator->setArgs($args);
 
         $this->assertIsArray($validator->rules());

--- a/tests/Unit/App/GraphQL/Validators/Mutation/UserCreateValidatorTest.php
+++ b/tests/Unit/App/GraphQL/Validators/Mutation/UserCreateValidatorTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Tests\Unit\GraphQL\Validators\Mutation;
+namespace Tests\Unit\App\GraphQL\Validators\Mutation;
 
-use App\GraphQL\Validators\Mutation\PositionEditValidator;
+use App\GraphQL\Validators\Mutation\UserCreateValidator;
 use Nuwave\Lighthouse\Execution\Arguments\ArgumentSet;
 use Tests\TestCase;
 
-class PositionEditValidatorTest extends TestCase
+class UserCreateValidatorTest extends TestCase
 {
     /**
      * A basic unit test messages.
@@ -15,7 +15,7 @@ class PositionEditValidatorTest extends TestCase
      */
     public function test_messages()
     {
-        $validator = new PositionEditValidator();
+        $validator = new UserCreateValidator();
 
         $this->assertIsArray($validator->messages());
         $this->assertNotEmpty($validator->messages());
@@ -31,7 +31,7 @@ class PositionEditValidatorTest extends TestCase
         $args = new ArgumentSet();
         $args->toArray('id');
 
-        $validator = new PositionEditValidator();
+        $validator = new UserCreateValidator();
         $validator->setArgs($args);
 
         $this->assertIsArray($validator->rules());

--- a/tests/Unit/App/GraphQL/Validators/Mutation/UserEditValidatorTest.php
+++ b/tests/Unit/App/GraphQL/Validators/Mutation/UserEditValidatorTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Tests\Unit\GraphQL\Validators\Mutation;
+namespace Tests\Unit\App\GraphQL\Validators\Mutation;
 
-use App\GraphQL\Validators\Mutation\UserCreateValidator;
+use App\GraphQL\Validators\Mutation\UserEditValidator;
 use Nuwave\Lighthouse\Execution\Arguments\ArgumentSet;
 use Tests\TestCase;
 
-class UserCreateValidatorTest extends TestCase
+class UserEditValidatorTest extends TestCase
 {
     /**
      * A basic unit test messages.
@@ -15,7 +15,7 @@ class UserCreateValidatorTest extends TestCase
      */
     public function test_messages()
     {
-        $validator = new UserCreateValidator();
+        $validator = new UserEditValidator();
 
         $this->assertIsArray($validator->messages());
         $this->assertNotEmpty($validator->messages());
@@ -31,7 +31,7 @@ class UserCreateValidatorTest extends TestCase
         $args = new ArgumentSet();
         $args->toArray('id');
 
-        $validator = new UserCreateValidator();
+        $validator = new UserEditValidator();
         $validator->setArgs($args);
 
         $this->assertIsArray($validator->rules());

--- a/tests/Unit/App/Models/FundamentalTest.php
+++ b/tests/Unit/App/Models/FundamentalTest.php
@@ -2,10 +2,10 @@
 
 namespace Tests\Unit\App\Models;
 
-use Tests\TestCase;
+use App\Models\Fundamental;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use App\Models\Fundamental;
+use Tests\TestCase;
 
 class FundamentalTest extends TestCase
 {

--- a/tests/Unit/App/Policies/FundamentalPolicyTest.php
+++ b/tests/Unit/App/Policies/FundamentalPolicyTest.php
@@ -69,4 +69,35 @@ class FundamentalPolicyTest extends TestCase
             ],
         ];
     }
+
+    /**
+     * A basic unit test delete.
+     *
+     * @dataProvider deleteProvider
+     *
+     * @return void
+     */
+    public function test_delete(bool $expected): void
+    {
+        $user = $this->createMock(User::class);
+        $user->expects($this->once())
+            ->method('hasPermissionTo')
+            ->with('delete-fundamental')
+            ->willReturn($expected);
+
+        $fundamentalPolicy = new FundamentalPolicy();
+        $fundamentalPolicy->delete($user);
+    }
+
+    public function deleteProvider(): array
+    {
+        return [
+            'when permission allows' => [
+                true,
+            ],
+            'when permission does not allow' => [
+                false
+            ],
+        ];
+    }
 }

--- a/tests/Unit/App/Policies/FundamentalPolicyTest.php
+++ b/tests/Unit/App/Policies/FundamentalPolicyTest.php
@@ -11,7 +11,7 @@ class FundamentalPolicyTest extends TestCase
     /**
      * A basic unit test create.
      *
-     * @dataProvider createProvider
+     * @dataProvider permissionProvider
      *
      * @return void
      */
@@ -27,22 +27,10 @@ class FundamentalPolicyTest extends TestCase
         $fundamentalPolicy->create($user);
     }
 
-    public function createProvider(): array
-    {
-        return [
-            'when permission allows' => [
-                true,
-            ],
-            'when permission does not allow' => [
-                false
-            ],
-        ];
-    }
-
     /**
      * A basic unit test edit.
      *
-     * @dataProvider editProvider
+     * @dataProvider permissionProvider
      *
      * @return void
      */
@@ -58,22 +46,10 @@ class FundamentalPolicyTest extends TestCase
         $fundamentalPolicy->edit($user);
     }
 
-    public function editProvider(): array
-    {
-        return [
-            'when permission allows' => [
-                true,
-            ],
-            'when permission does not allow' => [
-                false
-            ],
-        ];
-    }
-
     /**
      * A basic unit test delete.
      *
-     * @dataProvider deleteProvider
+     * @dataProvider permissionProvider
      *
      * @return void
      */
@@ -87,17 +63,5 @@ class FundamentalPolicyTest extends TestCase
 
         $fundamentalPolicy = new FundamentalPolicy();
         $fundamentalPolicy->delete($user);
-    }
-
-    public function deleteProvider(): array
-    {
-        return [
-            'when permission allows' => [
-                true,
-            ],
-            'when permission does not allow' => [
-                false
-            ],
-        ];
     }
 }

--- a/tests/Unit/App/Policies/FundamentalPolicyTest.php
+++ b/tests/Unit/App/Policies/FundamentalPolicyTest.php
@@ -2,9 +2,9 @@
 
 namespace Tests\Unit\App\Policies;
 
-use Tests\TestCase;
-use App\Policies\FundamentalPolicy;
 use App\Models\User;
+use App\Policies\FundamentalPolicy;
+use Tests\TestCase;
 
 class FundamentalPolicyTest extends TestCase
 {

--- a/tests/Unit/App/Policies/PositionPolicyTest.php
+++ b/tests/Unit/App/Policies/PositionPolicyTest.php
@@ -11,7 +11,7 @@ class PositionPolicyTest extends TestCase
     /**
      * A basic unit test create.
      *
-     * @dataProvider createProvider
+     * @dataProvider permissionProvider
      *
      * @return void
      */
@@ -27,22 +27,10 @@ class PositionPolicyTest extends TestCase
         $positionPolicy->create($user);
     }
 
-    public function createProvider(): array
-    {
-        return [
-            'when permission allows' => [
-                true,
-            ],
-            'when permission does not allow' => [
-                false
-            ],
-        ];
-    }
-
     /**
      * A basic unit test edit.
      *
-     * @dataProvider editProvider
+     * @dataProvider permissionProvider
      *
      * @return void
      */
@@ -58,22 +46,10 @@ class PositionPolicyTest extends TestCase
         $positionPolicy->edit($user);
     }
 
-    public function editProvider(): array
-    {
-        return [
-            'when permission allows' => [
-                true,
-            ],
-            'when permission does not allow' => [
-                false
-            ],
-        ];
-    }
-
     /**
      * A basic unit test delete.
      *
-     * @dataProvider deleteProvider
+     * @dataProvider permissionProvider
      *
      * @return void
      */
@@ -87,17 +63,5 @@ class PositionPolicyTest extends TestCase
 
         $positionPolicy = new PositionPolicy();
         $positionPolicy->delete($user);
-    }
-
-    public function deleteProvider(): array
-    {
-        return [
-            'when permission allows' => [
-                true,
-            ],
-            'when permission does not allow' => [
-                false
-            ],
-        ];
     }
 }

--- a/tests/Unit/App/Policies/PositionPolicyTest.php
+++ b/tests/Unit/App/Policies/PositionPolicyTest.php
@@ -69,4 +69,35 @@ class PositionPolicyTest extends TestCase
             ],
         ];
     }
+
+    /**
+     * A basic unit test delete.
+     *
+     * @dataProvider deleteProvider
+     *
+     * @return void
+     */
+    public function test_delete(bool $expected): void
+    {
+        $user = $this->createMock(User::class);
+        $user->expects($this->once())
+            ->method('hasPermissionTo')
+            ->with('delete-position')
+            ->willReturn($expected);
+
+        $positionPolicy = new PositionPolicy();
+        $positionPolicy->delete($user);
+    }
+
+    public function deleteProvider(): array
+    {
+        return [
+            'when permission allows' => [
+                true,
+            ],
+            'when permission does not allow' => [
+                false
+            ],
+        ];
+    }
 }

--- a/tests/Unit/App/Policies/SpecificFundamentalPolicyTest.php
+++ b/tests/Unit/App/Policies/SpecificFundamentalPolicyTest.php
@@ -69,4 +69,35 @@ class SpecificFundamentalPolicyTest extends TestCase
             ],
         ];
     }
+
+    /**
+     * A basic unit test delete.
+     *
+     * @dataProvider deleteProvider
+     *
+     * @return void
+     */
+    public function test_delete(bool $expected): void
+    {
+        $user = $this->createMock(User::class);
+        $user->expects($this->once())
+            ->method('hasPermissionTo')
+            ->with('delete-specific-fundamental')
+            ->willReturn($expected);
+
+        $specificFundamentalPolicy = new SpecificFundamentalPolicy();
+        $specificFundamentalPolicy->delete($user);
+    }
+
+    public function deleteProvider(): array
+    {
+        return [
+            'when permission allows' => [
+                true,
+            ],
+            'when permission does not allow' => [
+                false
+            ],
+        ];
+    }
 }

--- a/tests/Unit/App/Policies/SpecificFundamentalPolicyTest.php
+++ b/tests/Unit/App/Policies/SpecificFundamentalPolicyTest.php
@@ -11,7 +11,7 @@ class SpecificFundamentalPolicyTest extends TestCase
     /**
      * A basic unit test create.
      *
-     * @dataProvider createProvider
+     * @dataProvider permissionProvider
      *
      * @return void
      */
@@ -27,22 +27,10 @@ class SpecificFundamentalPolicyTest extends TestCase
         $specificFundamentalPolicy->create($user);
     }
 
-    public function createProvider(): array
-    {
-        return [
-            'when permission allows' => [
-                true,
-            ],
-            'when permission does not allow' => [
-                false
-            ],
-        ];
-    }
-
     /**
      * A basic unit test edit.
      *
-     * @dataProvider editProvider
+     * @dataProvider permissionProvider
      *
      * @return void
      */
@@ -58,22 +46,10 @@ class SpecificFundamentalPolicyTest extends TestCase
         $specificFundamentalPolicy->edit($user);
     }
 
-    public function editProvider(): array
-    {
-        return [
-            'when permission allows' => [
-                true,
-            ],
-            'when permission does not allow' => [
-                false
-            ],
-        ];
-    }
-
     /**
      * A basic unit test delete.
      *
-     * @dataProvider deleteProvider
+     * @dataProvider permissionProvider
      *
      * @return void
      */
@@ -87,17 +63,5 @@ class SpecificFundamentalPolicyTest extends TestCase
 
         $specificFundamentalPolicy = new SpecificFundamentalPolicy();
         $specificFundamentalPolicy->delete($user);
-    }
-
-    public function deleteProvider(): array
-    {
-        return [
-            'when permission allows' => [
-                true,
-            ],
-            'when permission does not allow' => [
-                false
-            ],
-        ];
     }
 }

--- a/tests/Unit/App/Policies/SpecificFundamentalPolicyTest.php
+++ b/tests/Unit/App/Policies/SpecificFundamentalPolicyTest.php
@@ -2,9 +2,9 @@
 
 namespace Tests\Unit\App\Policies;
 
-use Tests\TestCase;
-use App\Policies\SpecificFundamentalPolicy;
 use App\Models\User;
+use App\Policies\SpecificFundamentalPolicy;
+use Tests\TestCase;
 
 class SpecificFundamentalPolicyTest extends TestCase
 {

--- a/tests/Unit/App/Policies/TeamPolicyTest.php
+++ b/tests/Unit/App/Policies/TeamPolicyTest.php
@@ -11,7 +11,7 @@ class TeamPolicyTest extends TestCase
     /**
      * A basic unit test create.
      *
-     * @dataProvider createProvider
+     * @dataProvider permissionProvider
      *
      * @return void
      */
@@ -27,22 +27,10 @@ class TeamPolicyTest extends TestCase
         $teamPolicy->create($user);
     }
 
-    public function createProvider(): array
-    {
-        return [
-            'when permission allows' => [
-                true,
-            ],
-            'when permission does not allow' => [
-                false
-            ],
-        ];
-    }
-
     /**
      * A basic unit test edit.
      *
-     * @dataProvider editProvider
+     * @dataProvider permissionProvider
      *
      * @return void
      */
@@ -58,22 +46,10 @@ class TeamPolicyTest extends TestCase
         $teamPolicy->edit($user);
     }
 
-    public function editProvider(): array
-    {
-        return [
-            'when permission allows' => [
-                true,
-            ],
-            'when permission does not allow' => [
-                false
-            ],
-        ];
-    }
-
     /**
      * A basic unit test delete.
      *
-     * @dataProvider deleteProvider
+     * @dataProvider permissionProvider
      *
      * @return void
      */
@@ -87,17 +63,5 @@ class TeamPolicyTest extends TestCase
 
         $teamPolicy = new TeamPolicy();
         $teamPolicy->delete($user);
-    }
-
-    public function deleteProvider(): array
-    {
-        return [
-            'when permission allows' => [
-                true,
-            ],
-            'when permission does not allow' => [
-                false
-            ],
-        ];
     }
 }

--- a/tests/Unit/App/Policies/TeamPolicyTest.php
+++ b/tests/Unit/App/Policies/TeamPolicyTest.php
@@ -2,9 +2,9 @@
 
 namespace Tests\Unit\App\Policies;
 
-use Tests\TestCase;
-use App\Policies\TeamPolicy;
 use App\Models\User;
+use App\Policies\TeamPolicy;
+use Tests\TestCase;
 
 class TeamPolicyTest extends TestCase
 {

--- a/tests/Unit/App/Policies/TeamPolicyTest.php
+++ b/tests/Unit/App/Policies/TeamPolicyTest.php
@@ -70,7 +70,7 @@ class TeamPolicyTest extends TestCase
         ];
     }
 
-        /**
+    /**
      * A basic unit test delete.
      *
      * @dataProvider deleteProvider

--- a/tests/Unit/App/Policies/TeamPolicyTest.php
+++ b/tests/Unit/App/Policies/TeamPolicyTest.php
@@ -69,4 +69,35 @@ class TeamPolicyTest extends TestCase
             ],
         ];
     }
+
+        /**
+     * A basic unit test delete.
+     *
+     * @dataProvider deleteProvider
+     *
+     * @return void
+     */
+    public function test_delete(bool $expected): void
+    {
+        $user = $this->createMock(User::class);
+        $user->expects($this->once())
+            ->method('hasPermissionTo')
+            ->with('delete-team')
+            ->willReturn($expected);
+
+        $teamPolicy = new TeamPolicy();
+        $teamPolicy->delete($user);
+    }
+
+    public function deleteProvider(): array
+    {
+        return [
+            'when permission allows' => [
+                true,
+            ],
+            'when permission does not allow' => [
+                false
+            ],
+        ];
+    }
 }

--- a/tests/Unit/App/Policies/UserPolicyTest.php
+++ b/tests/Unit/App/Policies/UserPolicyTest.php
@@ -11,7 +11,7 @@ class UserPolicyTest extends TestCase
     /**
      * A basic unit test create.
      *
-     * @dataProvider createProvider
+     * @dataProvider permissionProvider
      *
      * @return void
      */
@@ -42,7 +42,7 @@ class UserPolicyTest extends TestCase
     /**
      * A basic unit test edit.
      *
-     * @dataProvider editProvider
+     * @dataProvider permissionProvider
      *
      * @return void
      */
@@ -58,22 +58,10 @@ class UserPolicyTest extends TestCase
         $userPolicy->edit($user);
     }
 
-    public function editProvider(): array
-    {
-        return [
-            'when permission allows' => [
-                true,
-            ],
-            'when permission does not allow' => [
-                false
-            ],
-        ];
-    }
-
     /**
      * A basic unit test delete.
      *
-     * @dataProvider deleteProvider
+     * @dataProvider permissionProvider
      *
      * @return void
      */
@@ -87,17 +75,5 @@ class UserPolicyTest extends TestCase
 
         $userPolicy = new UserPolicy();
         $userPolicy->delete($user);
-    }
-
-    public function deleteProvider(): array
-    {
-        return [
-            'when permission allows' => [
-                true,
-            ],
-            'when permission does not allow' => [
-                false
-            ],
-        ];
     }
 }

--- a/tests/Unit/App/Policies/UserPolicyTest.php
+++ b/tests/Unit/App/Policies/UserPolicyTest.php
@@ -69,4 +69,35 @@ class UserPolicyTest extends TestCase
             ],
         ];
     }
+
+    /**
+     * A basic unit test delete.
+     *
+     * @dataProvider deleteProvider
+     *
+     * @return void
+     */
+    public function test_delete(bool $expected): void
+    {
+        $user = $this->createMock(User::class);
+        $user->expects($this->once())
+            ->method('hasPermissionTo')
+            ->with('delete-user')
+            ->willReturn($expected);
+
+        $userPolicy = new UserPolicy();
+        $userPolicy->delete($user);
+    }
+
+    public function deleteProvider(): array
+    {
+        return [
+            'when permission allows' => [
+                true,
+            ],
+            'when permission does not allow' => [
+                false
+            ],
+        ];
+    }
 }

--- a/tests/Unit/App/Policies/UserPolicyTest.php
+++ b/tests/Unit/App/Policies/UserPolicyTest.php
@@ -2,9 +2,9 @@
 
 namespace Tests\Unit\App\Policies;
 
-use Tests\TestCase;
-use App\Policies\UserPolicy;
 use App\Models\User;
+use App\Policies\UserPolicy;
+use Tests\TestCase;
 
 class UserPolicyTest extends TestCase
 {

--- a/tests/Unit/App/Rules/PermissionAssignmentTest.php
+++ b/tests/Unit/App/Rules/PermissionAssignmentTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Unit\App\Rules;
 
-use Tests\TestCase;
 use App\Rules\PermissionAssignment;
+use Tests\TestCase;
 
 class PermissionAssignmentTest extends TestCase
 {
@@ -15,6 +15,6 @@ class PermissionAssignmentTest extends TestCase
     public function test_message()
     {
         $permissionAssignment = new PermissionAssignment();
-        $this->assertIsString( $permissionAssignment->message());
+        $this->assertIsString($permissionAssignment->message());
     }
 }


### PR DESCRIPTION
### O que?

Todos os cadastros no sistema foram levados em consideração apenas os métodos de criar e editar, agora é a vez de adicionar as funções de excluir para o sistema.

### Por quê?

Para as regras de negócio também é necessário excluir alguns registros no sistema.

### Verificações
- [x] Lembrete: Ajustar o `composer.json` com a versão.

