### PR TITLE
Permissões: Ajustando permissões no sistema - VLC-31

### DIFF
--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -25,7 +25,7 @@ class Role extends SpatieRole
              * if not, remove role id 1 from query (admin)
              */
             return $builder->when(
-                ! auth()->user()->hasRoleAdmin(),
+                ! auth()->user()->hasPermissionRole('view-role-admin'),
                 function (Builder $builder) {
                     $builder->whereNot('id', 1);
                 }
@@ -36,7 +36,7 @@ class Role extends SpatieRole
              * if not, remove role id 2 from query (Técnico)
              */
             ->when(
-                ! auth()->user()->hasRoleTechnician(),
+                ! auth()->user()->hasPermissionRole('view-role-technician'),
                 function (Builder $builder) {
                     $builder->whereNot('id', 2);
                 }
@@ -46,7 +46,7 @@ class Role extends SpatieRole
              * if not, remove role id 3 from query (Jogador)
              */
             ->when(
-                ! auth()->user()->hasRolePlayer(),
+                ! auth()->user()->hasPermissionRole('view-role-player'),
                 function (Builder $builder) {
                     $builder->whereNot('id', 3);
                 }

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -25,7 +25,7 @@ class Role extends SpatieRole
              * if not, remove role id 1 from query (admin)
              */
             return $builder->when(
-                ! auth()->user()->hasPermissionRole('view-role-admin'),
+                ! auth()->user()->hasRoleAdmin(),
                 function (Builder $builder) {
                     $builder->whereNot('id', 1);
                 }
@@ -36,7 +36,7 @@ class Role extends SpatieRole
              * if not, remove role id 2 from query (Técnico)
              */
             ->when(
-                ! auth()->user()->hasPermissionRole('view-role-technician'),
+                ! auth()->user()->hasRoleTechnician(),
                 function (Builder $builder) {
                     $builder->whereNot('id', 2);
                 }
@@ -46,7 +46,7 @@ class Role extends SpatieRole
              * if not, remove role id 3 from query (Jogador)
              */
             ->when(
-                ! auth()->user()->hasPermissionRole('view-role-player'),
+                ! auth()->user()->hasRolePlayer(),
                 function (Builder $builder) {
                     $builder->whereNot('id', 3);
                 }

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -21,32 +21,32 @@ class Role extends SpatieRole
     {
         static::addGlobalScope('permission', function (Builder $builder) {
             /**
-             * verify if auth()->user() has permission in role for list-role-administrador
-             * if not, remove role id 1 from query (Administrador)
+             * verify if auth()->user() has permission in role for view-role-admin
+             * if not, remove role id 1 from query (admin)
              */
             return $builder->when(
-                ! auth()->user()->hasPermissionRole('list-role-administrador'),
+                ! auth()->user()->hasPermissionRole('view-role-admin'),
                 function (Builder $builder) {
                     $builder->whereNot('id', 1);
                 }
             )
 
             /**
-             * verify if auth()->user() has permission in role for list-role-technician
+             * verify if auth()->user() has permission in role for view-role-technician
              * if not, remove role id 2 from query (Técnico)
              */
             ->when(
-                ! auth()->user()->hasPermissionRole('list-role-technician'),
+                ! auth()->user()->hasPermissionRole('view-role-technician'),
                 function (Builder $builder) {
                     $builder->whereNot('id', 2);
                 }
             )
             /**
-             * verify if auth()->user() has permission in role for list-role-player
+             * verify if auth()->user() has permission in role for view-role-player
              * if not, remove role id 3 from query (Jogador)
              */
             ->when(
-                ! auth()->user()->hasPermissionRole('list-role-player'),
+                ! auth()->user()->hasPermissionRole('view-role-player'),
                 function (Builder $builder) {
                     $builder->whereNot('id', 3);
                 }

--- a/app/Models/TeamsUsers.php
+++ b/app/Models/TeamsUsers.php
@@ -46,7 +46,7 @@ class TeamsUsers extends Pivot
 
     public function updateRoleInRelationship()
     {
-        if ($this->user->find($this->user_id)->hasRole('Técnico')) {
+        if ($this->user->find($this->user_id)->hasRole('technician')) {
             $this->role = 'technician';
         }
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -116,7 +116,7 @@ class User extends Authenticatable implements HasApiTokensContract
      */
     public function hasRoleTechnician(): bool
     {
-        return $this->hasRole('Técnico');
+        return $this->hasRole('technician');
     }
 
     /**
@@ -126,6 +126,16 @@ class User extends Authenticatable implements HasApiTokensContract
      */
     public function hasRolePlayer(): bool
     {
-        return $this->hasRole('Jogador');
+        return $this->hasRole('player');
+    }
+
+    /**
+     * @codeCoverageIgnore
+     *
+     * @return bool
+     */
+    public function hasRoleAdmin(): bool
+    {
+        return $this->hasRole('admin');
     }
 }

--- a/app/Policies/ConfigPolicy.php
+++ b/app/Policies/ConfigPolicy.php
@@ -9,8 +9,27 @@ class ConfigPolicy
 {
     use HandlesAuthorization;
 
+    /**
+     * Edit a config instance.
+     * 
+     * @param User $user
+     * 
+     * @return bool
+     */
     public function edit(User $user): bool
     {
         return $user->hasPermissionTo('edit-config');
+    }
+
+    /**
+     * View a config instance.
+     * 
+     * @param User $user
+     * 
+     * @return bool
+     */
+    public function view(User $user): bool
+    {
+        return $user->hasPermissionTo('edit-config') || $user->hasPermissionTo('view-config');
     }
 }

--- a/app/Policies/ConfigPolicy.php
+++ b/app/Policies/ConfigPolicy.php
@@ -11,9 +11,8 @@ class ConfigPolicy
 
     /**
      * Edit a config instance.
-     * 
-     * @param User $user
-     * 
+     *
+     * @param  User  $user
      * @return bool
      */
     public function edit(User $user): bool
@@ -23,9 +22,8 @@ class ConfigPolicy
 
     /**
      * View a config instance.
-     * 
-     * @param User $user
-     * 
+     *
+     * @param  User  $user
      * @return bool
      */
     public function view(User $user): bool

--- a/app/Policies/FundamentalPolicy.php
+++ b/app/Policies/FundamentalPolicy.php
@@ -11,7 +11,7 @@ class FundamentalPolicy
 
     public function create(User $user): bool
     {
-        return $user->hasPermissionTo('create-fundamental');
+        return $user->hasPermissionTo('edit-fundamental');
     }
 
     public function edit(User $user): bool
@@ -21,6 +21,6 @@ class FundamentalPolicy
 
     public function delete(User $user): bool
     {
-        return $user->hasPermissionTo('delete-fundamental');
+        return $user->hasPermissionTo('edit-fundamental');
     }
 }

--- a/app/Policies/FundamentalPolicy.php
+++ b/app/Policies/FundamentalPolicy.php
@@ -9,18 +9,51 @@ class FundamentalPolicy
 {
     use HandlesAuthorization;
 
+    /**
+     * Create a new fundamental instance.
+     * 
+     * @param User $user
+     * 
+     * @return bool
+     */
     public function create(User $user): bool
     {
         return $user->hasPermissionTo('edit-fundamental');
     }
 
+    /**
+     * Edit a fundamental instance.
+     * 
+     * @param User $user
+     * 
+     * @return bool
+     */
     public function edit(User $user): bool
     {
         return $user->hasPermissionTo('edit-fundamental');
     }
 
+    /**
+     * Delete a fundamental instance.
+     * 
+     * @param User $user
+     * 
+     * @return bool
+     */
     public function delete(User $user): bool
     {
         return $user->hasPermissionTo('edit-fundamental');
+    }
+
+    /**
+     * View a fundamental instance.
+     * 
+     * @param User $user
+     * 
+     * @return bool
+     */
+    public function view(User $user): bool
+    {
+        return $user->hasPermissionTo('edit-fundamental') || $user->hasPermissionTo('view-fundamental');
     }
 }

--- a/app/Policies/FundamentalPolicy.php
+++ b/app/Policies/FundamentalPolicy.php
@@ -11,9 +11,8 @@ class FundamentalPolicy
 
     /**
      * Create a new fundamental instance.
-     * 
-     * @param User $user
-     * 
+     *
+     * @param  User  $user
      * @return bool
      */
     public function create(User $user): bool
@@ -23,9 +22,8 @@ class FundamentalPolicy
 
     /**
      * Edit a fundamental instance.
-     * 
-     * @param User $user
-     * 
+     *
+     * @param  User  $user
      * @return bool
      */
     public function edit(User $user): bool
@@ -35,9 +33,8 @@ class FundamentalPolicy
 
     /**
      * Delete a fundamental instance.
-     * 
-     * @param User $user
-     * 
+     *
+     * @param  User  $user
      * @return bool
      */
     public function delete(User $user): bool
@@ -47,9 +44,8 @@ class FundamentalPolicy
 
     /**
      * View a fundamental instance.
-     * 
-     * @param User $user
-     * 
+     *
+     * @param  User  $user
      * @return bool
      */
     public function view(User $user): bool

--- a/app/Policies/PositionPolicy.php
+++ b/app/Policies/PositionPolicy.php
@@ -3,7 +3,6 @@
 namespace App\Policies;
 
 use App\Models\User;
-use App\Models\Position;
 use Illuminate\Auth\Access\HandlesAuthorization;
 
 class PositionPolicy
@@ -46,7 +45,7 @@ class PositionPolicy
      *
      * @return bool
      */
-    public function view(User $user, Position $position): bool
+    public function view(User $user): bool
     {
         return $user->hasPermissionTo('edit-position') || $user->hasPermissionTo('view-position');
     }

--- a/app/Policies/PositionPolicy.php
+++ b/app/Policies/PositionPolicy.php
@@ -16,7 +16,7 @@ class PositionPolicy
      */
     public function create(User $user): bool
     {
-        return $user->hasPermissionTo('create-position');
+        return $user->hasPermissionTo('edit-position');
     }
 
     public function edit(User $user): bool
@@ -26,6 +26,6 @@ class PositionPolicy
 
     public function delete(User $user): bool
     {
-        return $user->hasPermissionTo('delete-position');
+        return $user->hasPermissionTo('edit-position');
     }
 }

--- a/app/Policies/PositionPolicy.php
+++ b/app/Policies/PositionPolicy.php
@@ -29,7 +29,6 @@ class PositionPolicy
         return $user->hasPermissionTo('edit-position');
     }
 
-
     /**
      * Delete a position instance.
      *

--- a/app/Policies/PositionPolicy.php
+++ b/app/Policies/PositionPolicy.php
@@ -3,6 +3,7 @@
 namespace App\Policies;
 
 use App\Models\User;
+use App\Models\Position;
 use Illuminate\Auth\Access\HandlesAuthorization;
 
 class PositionPolicy
@@ -12,20 +13,41 @@ class PositionPolicy
     /**
      * Create a new policy instance.
      *
-     * @return void
+     * @return bool
      */
     public function create(User $user): bool
     {
         return $user->hasPermissionTo('edit-position');
     }
 
+    /**
+     * Edit a policy instance.
+     *
+     * @return bool
+     */
     public function edit(User $user): bool
     {
         return $user->hasPermissionTo('edit-position');
     }
 
+
+    /**
+     * Delete a policy instance.
+     *
+     * @return bool
+     */
     public function delete(User $user): bool
     {
         return $user->hasPermissionTo('edit-position');
+    }
+
+    /**
+     * View a policy instance.
+     *
+     * @return bool
+     */
+    public function view(User $user, Position $position): bool
+    {
+        return $user->hasPermissionTo('edit-position') || $user->hasPermissionTo('view-position');
     }
 }

--- a/app/Policies/PositionPolicy.php
+++ b/app/Policies/PositionPolicy.php
@@ -11,7 +11,7 @@ class PositionPolicy
     use HandlesAuthorization;
 
     /**
-     * Create a new policy instance.
+     * Create a new position instance.
      *
      * @return bool
      */
@@ -21,7 +21,7 @@ class PositionPolicy
     }
 
     /**
-     * Edit a policy instance.
+     * Edit a position instance.
      *
      * @return bool
      */
@@ -32,7 +32,7 @@ class PositionPolicy
 
 
     /**
-     * Delete a policy instance.
+     * Delete a position instance.
      *
      * @return bool
      */
@@ -42,7 +42,7 @@ class PositionPolicy
     }
 
     /**
-     * View a policy instance.
+     * View a position instance.
      *
      * @return bool
      */

--- a/app/Policies/SpecificFundamentalPolicy.php
+++ b/app/Policies/SpecificFundamentalPolicy.php
@@ -11,7 +11,7 @@ class SpecificFundamentalPolicy
 
     public function create(User $user): bool
     {
-        return $user->hasPermissionTo('create-specific-fundamental');
+        return $user->hasPermissionTo('edit-specific-fundamental');
     }
 
     public function edit(User $user): bool
@@ -21,6 +21,6 @@ class SpecificFundamentalPolicy
 
     public function delete(User $user): bool
     {
-        return $user->hasPermissionTo('delete-specific-fundamental');
+        return $user->hasPermissionTo('edit-specific-fundamental');
     }
 }

--- a/app/Policies/SpecificFundamentalPolicy.php
+++ b/app/Policies/SpecificFundamentalPolicy.php
@@ -9,18 +9,51 @@ class SpecificFundamentalPolicy
 {
     use HandlesAuthorization;
 
+    /**
+     * Create a new specific fundamental instance.
+     * 
+     * @param User $user
+     * 
+     * @return bool
+     */
     public function create(User $user): bool
     {
         return $user->hasPermissionTo('edit-specific-fundamental');
     }
 
+    /**
+     * Edit a specific fundamental instance.
+     * 
+     * @param User $user
+     * 
+     * @return bool
+     */
     public function edit(User $user): bool
     {
         return $user->hasPermissionTo('edit-specific-fundamental');
     }
 
+    /**
+     * Delete a specific fundamental instance.
+     * 
+     * @param User $user
+     * 
+     * @return bool
+     */
     public function delete(User $user): bool
     {
         return $user->hasPermissionTo('edit-specific-fundamental');
+    }
+
+    /**
+     * View a specific fundamental instance.
+     * 
+     * @param User $user
+     * 
+     * @return bool
+     */
+    public function view(User $user): bool
+    {
+        return $user->hasPermissionTo('edit-specific-fundamental') || $user->hasPermissionTo('view-specific-fundamental');
     }
 }

--- a/app/Policies/SpecificFundamentalPolicy.php
+++ b/app/Policies/SpecificFundamentalPolicy.php
@@ -50,6 +50,7 @@ class SpecificFundamentalPolicy
      */
     public function view(User $user): bool
     {
-        return $user->hasPermissionTo('edit-specific-fundamental') || $user->hasPermissionTo('view-specific-fundamental');
+        return $user->hasPermissionTo('edit-specific-fundamental') ||
+            $user->hasPermissionTo('view-specific-fundamental');
     }
 }

--- a/app/Policies/SpecificFundamentalPolicy.php
+++ b/app/Policies/SpecificFundamentalPolicy.php
@@ -11,9 +11,8 @@ class SpecificFundamentalPolicy
 
     /**
      * Create a new specific fundamental instance.
-     * 
-     * @param User $user
-     * 
+     *
+     * @param  User  $user
      * @return bool
      */
     public function create(User $user): bool
@@ -23,9 +22,8 @@ class SpecificFundamentalPolicy
 
     /**
      * Edit a specific fundamental instance.
-     * 
-     * @param User $user
-     * 
+     *
+     * @param  User  $user
      * @return bool
      */
     public function edit(User $user): bool
@@ -35,9 +33,8 @@ class SpecificFundamentalPolicy
 
     /**
      * Delete a specific fundamental instance.
-     * 
-     * @param User $user
-     * 
+     *
+     * @param  User  $user
      * @return bool
      */
     public function delete(User $user): bool
@@ -47,9 +44,8 @@ class SpecificFundamentalPolicy
 
     /**
      * View a specific fundamental instance.
-     * 
-     * @param User $user
-     * 
+     *
+     * @param  User  $user
      * @return bool
      */
     public function view(User $user): bool

--- a/app/Policies/TeamPolicy.php
+++ b/app/Policies/TeamPolicy.php
@@ -9,18 +9,51 @@ class TeamPolicy
 {
     use HandlesAuthorization;
 
+    /**
+     * Create a new team instance.
+     * 
+     * @param User $user
+     * 
+     * @return bool
+     */
     public function create(User $user): bool
     {
         return $user->hasPermissionTo('edit-team');
     }
 
+    /**
+     * Edit a team instance.
+     * 
+     * @param User $user
+     * 
+     * @return bool
+     */
     public function edit(User $user): bool
     {
         return $user->hasPermissionTo('edit-team');
     }
 
+    /**
+     * Delete a team instance.
+     * 
+     * @param User $user
+     * 
+     * @return bool
+     */
     public function delete(User $user): bool
     {
         return $user->hasPermissionTo('edit-team');
+    }
+
+    /**
+     * View a team instance.
+     * 
+     * @param User $user
+     * 
+     * @return bool
+     */
+    public function view(User $user): bool
+    {
+        return $user->hasPermissionTo('edit-team') || $user->hasPermissionTo('view-team');
     }
 }

--- a/app/Policies/TeamPolicy.php
+++ b/app/Policies/TeamPolicy.php
@@ -11,9 +11,8 @@ class TeamPolicy
 
     /**
      * Create a new team instance.
-     * 
-     * @param User $user
-     * 
+     *
+     * @param  User  $user
      * @return bool
      */
     public function create(User $user): bool
@@ -23,9 +22,8 @@ class TeamPolicy
 
     /**
      * Edit a team instance.
-     * 
-     * @param User $user
-     * 
+     *
+     * @param  User  $user
      * @return bool
      */
     public function edit(User $user): bool
@@ -35,9 +33,8 @@ class TeamPolicy
 
     /**
      * Delete a team instance.
-     * 
-     * @param User $user
-     * 
+     *
+     * @param  User  $user
      * @return bool
      */
     public function delete(User $user): bool
@@ -47,9 +44,8 @@ class TeamPolicy
 
     /**
      * View a team instance.
-     * 
-     * @param User $user
-     * 
+     *
+     * @param  User  $user
      * @return bool
      */
     public function view(User $user): bool

--- a/app/Policies/TeamPolicy.php
+++ b/app/Policies/TeamPolicy.php
@@ -11,7 +11,7 @@ class TeamPolicy
 
     public function create(User $user): bool
     {
-        return $user->hasPermissionTo('create-team');
+        return $user->hasPermissionTo('edit-team');
     }
 
     public function edit(User $user): bool
@@ -21,6 +21,6 @@ class TeamPolicy
 
     public function delete(User $user): bool
     {
-        return $user->hasPermissionTo('delete-team');
+        return $user->hasPermissionTo('edit-team');
     }
 }

--- a/app/Policies/TrainingConfigPolicy.php
+++ b/app/Policies/TrainingConfigPolicy.php
@@ -9,8 +9,27 @@ class TrainingConfigPolicy
 {
     use HandlesAuthorization;
 
+    /**
+     * Edit a training config instance.
+     * 
+     * @param User $user
+     * 
+     * @return bool
+     */
     public function edit(User $user): bool
     {
         return $user->hasPermissionTo('edit-training-config');
+    }
+
+    /**
+     * View a training config instance.
+     * 
+     * @param User $user
+     * 
+     * @return bool
+     */
+    public function view(User $user): bool
+    {
+        return $user->hasPermissionTo('edit-training-config') || $user->hasPermissionTo('view-training-config');
     }
 }

--- a/app/Policies/TrainingConfigPolicy.php
+++ b/app/Policies/TrainingConfigPolicy.php
@@ -11,9 +11,8 @@ class TrainingConfigPolicy
 
     /**
      * Edit a training config instance.
-     * 
-     * @param User $user
-     * 
+     *
+     * @param  User  $user
      * @return bool
      */
     public function edit(User $user): bool
@@ -23,9 +22,8 @@ class TrainingConfigPolicy
 
     /**
      * View a training config instance.
-     * 
-     * @param User $user
-     * 
+     *
+     * @param  User  $user
      * @return bool
      */
     public function view(User $user): bool

--- a/app/Policies/TrainingPolicy.php
+++ b/app/Policies/TrainingPolicy.php
@@ -10,7 +10,7 @@ class TrainingPolicy
     use HandlesAuthorization;
 
     /**
-     * Create a new policy instance.
+     * Create a new training instance.
      *
      * @return void
      */
@@ -19,13 +19,39 @@ class TrainingPolicy
         return $user->hasPermissionTo('edit-training');
     }
 
+    /**
+     * Edit a training instance.
+     * 
+     * @param User $user
+     * 
+     * @return bool
+     */
     public function edit(User $user): bool
     {
         return $user->hasPermissionTo('edit-training');
     }
 
+    /**
+     * Delete a training instance.
+     * 
+     * @param User $user
+     * 
+     * @return bool
+     */
     public function delete(User $user): bool
     {
         return $user->hasPermissionTo('edit-training');
+    }
+
+    /**
+     * View a training instance.
+     * 
+     * @param User $user
+     * 
+     * @return bool
+     */
+    public function view(User $user): bool
+    {
+        return $user->hasPermissionTo('edit-training') || $user->hasPermissionTo('view-training');
     }
 }

--- a/app/Policies/TrainingPolicy.php
+++ b/app/Policies/TrainingPolicy.php
@@ -16,7 +16,7 @@ class TrainingPolicy
      */
     public function create(User $user): bool
     {
-        return $user->hasPermissionTo('create-training');
+        return $user->hasPermissionTo('edit-training');
     }
 
     public function edit(User $user): bool
@@ -26,6 +26,6 @@ class TrainingPolicy
 
     public function delete(User $user): bool
     {
-        return $user->hasPermissionTo('delete-training');
+        return $user->hasPermissionTo('edit-training');
     }
 }

--- a/app/Policies/TrainingPolicy.php
+++ b/app/Policies/TrainingPolicy.php
@@ -21,9 +21,8 @@ class TrainingPolicy
 
     /**
      * Edit a training instance.
-     * 
-     * @param User $user
-     * 
+     *
+     * @param  User  $user
      * @return bool
      */
     public function edit(User $user): bool
@@ -33,9 +32,8 @@ class TrainingPolicy
 
     /**
      * Delete a training instance.
-     * 
-     * @param User $user
-     * 
+     *
+     * @param  User  $user
      * @return bool
      */
     public function delete(User $user): bool
@@ -45,9 +43,8 @@ class TrainingPolicy
 
     /**
      * View a training instance.
-     * 
-     * @param User $user
-     * 
+     *
+     * @param  User  $user
      * @return bool
      */
     public function view(User $user): bool

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -11,7 +11,7 @@ class UserPolicy
 
     public function create(User $user): bool
     {
-        return $user->hasPermissionTo('create-user');
+        return $user->hasPermissionTo('edit-user');
     }
 
     public function edit(User $user): bool
@@ -21,6 +21,6 @@ class UserPolicy
 
     public function delete(User $user): bool
     {
-        return $user->hasPermissionTo('delete-user');
+        return $user->hasPermissionTo('edit-user');
     }
 }

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -9,18 +9,51 @@ class UserPolicy
 {
     use HandlesAuthorization;
 
+    /**
+     * Create a new user instance.
+     * 
+     * @param User $user
+     * 
+     * @return bool
+     */
     public function create(User $user): bool
     {
         return $user->hasPermissionTo('edit-user');
     }
 
+    /**
+     * Edit a user instance.
+     * 
+     * @param User $user
+     * 
+     * @return bool
+     */
     public function edit(User $user): bool
     {
         return $user->hasPermissionTo('edit-user');
     }
 
+    /**
+     * Delete a user instance.
+     * 
+     * @param User $user
+     * 
+     * @return bool
+     */
     public function delete(User $user): bool
     {
         return $user->hasPermissionTo('edit-user');
+    }
+
+    /**
+     * View a user instance.
+     * 
+     * @param User $user
+     * 
+     * @return bool
+     */
+    public function view(User $user): bool
+    {
+        return $user->hasPermissionTo('edit-user') || $user->hasPermissionTo('view-user');
     }
 }

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -11,9 +11,8 @@ class UserPolicy
 
     /**
      * Create a new user instance.
-     * 
-     * @param User $user
-     * 
+     *
+     * @param  User  $user
      * @return bool
      */
     public function create(User $user): bool
@@ -23,9 +22,8 @@ class UserPolicy
 
     /**
      * Edit a user instance.
-     * 
-     * @param User $user
-     * 
+     *
+     * @param  User  $user
      * @return bool
      */
     public function edit(User $user): bool
@@ -35,9 +33,8 @@ class UserPolicy
 
     /**
      * Delete a user instance.
-     * 
-     * @param User $user
-     * 
+     *
+     * @param  User  $user
      * @return bool
      */
     public function delete(User $user): bool
@@ -47,9 +44,8 @@ class UserPolicy
 
     /**
      * View a user instance.
-     * 
-     * @param User $user
-     * 
+     *
+     * @param  User  $user
      * @return bool
      */
     public function view(User $user): bool

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -30,7 +30,7 @@ class AuthServiceProvider extends ServiceProvider
         // Implicitly grant "Super Admin" role all permissions
         // This works in the app by using gate-related functions like auth()->user->can() and @can()
         Gate::before(function ($user) {
-            return $user->hasRole('Administrador') ? true : null;
+            return $user->hasRole('admin') ? true : null;
         });
     }
 }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -19,9 +19,9 @@ class UserFactory extends Factory
     public function definition()
     {
         //NOTE - Verificar manualmente se o email faker gerado é único, se não for, gerar outro
-        $email = $this->faker->unique()->safeEmail();
+        $email = $this->faker->unique()->safeEmail('users', 'email');
         while (User::where('email', $email)->exists()) {
-            $email = $this->faker->unique()->safeEmail();
+            $email = $this->faker->unique()->safeEmail('users', 'email');
         }
 
         return [

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -2,9 +2,9 @@
 
 namespace Database\Factories;
 
+use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
-use App\Models\User;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\User>

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -4,6 +4,7 @@ namespace Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
+use App\Models\User;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\User>
@@ -17,9 +18,15 @@ class UserFactory extends Factory
      */
     public function definition()
     {
+        //NOTE - Verificar manualmente se o email faker gerado é único, se não for, gerar outro
+        $email = $this->faker->unique()->safeEmail();
+        while (User::where('email', $email)->exists()) {
+            $email = $this->faker->unique()->safeEmail();
+        }
+
         return [
             'name' => $this->faker->name(),
-            'email' => $this->faker->unique()->safeEmail(),
+            'email' => $email,
             'email_verified_at' => now(),
             'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
             'remember_token' => Str::random(10),

--- a/database/seeders/tenants/PermissionTableSeeder.php
+++ b/database/seeders/tenants/PermissionTableSeeder.php
@@ -61,7 +61,7 @@ class PermissionTableSeeder extends Seeder
          */
         $role[] = Permission::updateOrCreate(['id' => 11], ['name' => 'edit-role']);
         $role[] = Permission::updateOrCreate(['id' => 12], ['name' => 'view-role']);
-        $role[] = Permission::updateOrCreate(['id' => 13], ['name' => 'view-role-admin']);
+        Permission::updateOrCreate(['id' => 13], ['name' => 'view-role-admin']);
         $role[] = Permission::updateOrCreate(['id' => 14], ['name' => 'view-role-technician']);
         $role[] = Permission::updateOrCreate(['id' => 15], ['name' => 'view-role-player']);
 

--- a/database/seeders/tenants/PermissionTableSeeder.php
+++ b/database/seeders/tenants/PermissionTableSeeder.php
@@ -59,27 +59,26 @@ class PermissionTableSeeder extends Seeder
         /**
          * Permissões de Funções
          */
-        Permission::updateOrCreate(['id' => 11], ['name' => 'view-role-admin']);
-        $role[] = Permission::updateOrCreate(['id' => 12], ['name' => 'view-role-technician']);
-        $role[] = Permission::updateOrCreate(['id' => 13], ['name' => 'view-role-player']);
+        $role[] = Permission::updateOrCreate(['id' => 11], ['name' => 'edit-role']);
+        $role[] = Permission::updateOrCreate(['id' => 12], ['name' => 'view-role']);
 
         /**
          * Permissões de Treinos
          */
-        $training[] = Permission::updateOrCreate(['id' => 14], ['name' => 'edit-training']);
-        $training[] = Permission::updateOrCreate(['id' => 15], ['name' => 'view-training']);
+        $training[] = Permission::updateOrCreate(['id' => 13], ['name' => 'edit-training']);
+        $training[] = Permission::updateOrCreate(['id' => 14], ['name' => 'view-training']);
 
         /**
          * Permissões de Configurações
          */
-        $config[] = Permission::updateOrCreate(['id' => 16], ['name' => 'edit-config']);
-        $config[] = Permission::updateOrCreate(['id' => 17], ['name' => 'view-config']);
+        $config[] = Permission::updateOrCreate(['id' => 15], ['name' => 'edit-config']);
+        $config[] = Permission::updateOrCreate(['id' => 16], ['name' => 'view-config']);
 
         /**
          * Permissões de Configurações de Treino
          */
-        $trainingConfig[] = Permission::updateOrCreate(['id' => 18], ['name' => 'edit-training-config']);
-        $trainingConfig[] = Permission::updateOrCreate(['id' => 19], ['name' => 'view-training-config']);
+        $trainingConfig[] = Permission::updateOrCreate(['id' => 17], ['name' => 'edit-training-config']);
+        $trainingConfig[] = Permission::updateOrCreate(['id' => 18], ['name' => 'view-training-config']);
 
         /**
          * Relacionando Permissões

--- a/database/seeders/tenants/PermissionTableSeeder.php
+++ b/database/seeders/tenants/PermissionTableSeeder.php
@@ -61,24 +61,27 @@ class PermissionTableSeeder extends Seeder
          */
         $role[] = Permission::updateOrCreate(['id' => 11], ['name' => 'edit-role']);
         $role[] = Permission::updateOrCreate(['id' => 12], ['name' => 'view-role']);
+        $role[] = Permission::updateOrCreate(['id' => 13], ['name' => 'view-role-admin']);
+        $role[] = Permission::updateOrCreate(['id' => 14], ['name' => 'view-role-technician']);
+        $role[] = Permission::updateOrCreate(['id' => 15], ['name' => 'view-role-player']);
 
         /**
          * Permissões de Treinos
          */
-        $training[] = Permission::updateOrCreate(['id' => 13], ['name' => 'edit-training']);
-        $training[] = Permission::updateOrCreate(['id' => 14], ['name' => 'view-training']);
+        $training[] = Permission::updateOrCreate(['id' => 16], ['name' => 'edit-training']);
+        $training[] = Permission::updateOrCreate(['id' => 17], ['name' => 'view-training']);
 
         /**
          * Permissões de Configurações
          */
-        $config[] = Permission::updateOrCreate(['id' => 15], ['name' => 'edit-config']);
-        $config[] = Permission::updateOrCreate(['id' => 16], ['name' => 'view-config']);
+        $config[] = Permission::updateOrCreate(['id' => 18], ['name' => 'edit-config']);
+        $config[] = Permission::updateOrCreate(['id' => 19], ['name' => 'view-config']);
 
         /**
          * Permissões de Configurações de Treino
          */
-        $trainingConfig[] = Permission::updateOrCreate(['id' => 17], ['name' => 'edit-training-config']);
-        $trainingConfig[] = Permission::updateOrCreate(['id' => 18], ['name' => 'view-training-config']);
+        $trainingConfig[] = Permission::updateOrCreate(['id' => 20], ['name' => 'edit-training-config']);
+        $trainingConfig[] = Permission::updateOrCreate(['id' => 21], ['name' => 'view-training-config']);
 
         /**
          * Relacionando Permissões

--- a/database/seeders/tenants/PermissionTableSeeder.php
+++ b/database/seeders/tenants/PermissionTableSeeder.php
@@ -20,84 +20,66 @@ class PermissionTableSeeder extends Seeder
         app()[\Spatie\Permission\PermissionRegistrar::class]->forgetCachedPermissions();
 
         /**
-         *Já estará como perfil de super administrador, e não precisará relacionar permissões neste perfil
+         *Já estará como perfil de super admin, e não precisará relacionar permissões neste perfil
          */
-        $admin = Role::updateOrCreate(['id' => 1], ['name' => 'Administrador', 'guard_name' => 'sanctum']);
-        $technician = Role::updateOrCreate(['id' => 2], ['name' => 'Técnico', 'guard_name' => 'sanctum']);
-        $player = Role::updateOrCreate(['id' => 3], ['name' => 'Jogador', 'guard_name' => 'sanctum']);
+        $admin = Role::updateOrCreate(['id' => 1], ['name' => 'admin', 'guard_name' => 'sanctum']);
+        $technician = Role::updateOrCreate(['id' => 2], ['name' => 'technician', 'guard_name' => 'sanctum']);
+        $player = Role::updateOrCreate(['id' => 3], ['name' => 'player', 'guard_name' => 'sanctum']);
 
         /**
          * Permissões Usuário
          */
-        $user[] = Permission::updateOrCreate(['id' => 1], ['name' => 'create-user']);
-        $user[] = Permission::updateOrCreate(['id' => 2], ['name' => 'edit-user']);
-        $user[] = Permission::updateOrCreate(['id' => 3], ['name' => 'list-user']);
-        $user[] = Permission::updateOrCreate(['id' => 4], ['name' => 'list-users']);
-        $user[] = Permission::updateOrCreate(['id' => 5], ['name' => 'delete-user']);
+        $user[] = Permission::updateOrCreate(['id' => 1], ['name' => 'edit-user']);
+        $user[] = Permission::updateOrCreate(['id' => 2], ['name' => 'view-user']);
 
         /**
          * Permissões Time
          */
-        $team[] = Permission::updateOrCreate(['id' => 6], ['name' => 'create-team']);
-        $team[] = Permission::updateOrCreate(['id' => 7], ['name' => 'edit-team']);
-        $team[] = Permission::updateOrCreate(['id' => 8], ['name' => 'list-team']);
-        $team[] = Permission::updateOrCreate(['id' => 9], ['name' => 'list-teams']);
-        $team[] = Permission::updateOrCreate(['id' => 10], ['name' => 'delete-team']);
+        $team[] = Permission::updateOrCreate(['id' => 3], ['name' => 'edit-team']);
+        $team[] = Permission::updateOrCreate(['id' => 4], ['name' => 'view-team']);
 
         /**
          * Permissões de Fundamentos
          */
-        $fundamental[] = Permission::updateOrCreate(['id' => 11], ['name' => 'create-fundamental']);
-        $fundamental[] = Permission::updateOrCreate(['id' => 12], ['name' => 'edit-fundamental']);
-        $fundamental[] = Permission::updateOrCreate(['id' => 13], ['name' => 'list-fundamental']);
-        $fundamental[] = Permission::updateOrCreate(['id' => 14], ['name' => 'list-fundamentals']);
-        $fundamental[] = Permission::updateOrCreate(['id' => 15], ['name' => 'delete-fundamental']);
+        $fundamental[] = Permission::updateOrCreate(['id' => 5], ['name' => 'edit-fundamental']);
+        $fundamental[] = Permission::updateOrCreate(['id' => 6], ['name' => 'view-fundamental']);
 
         /**
          * Permissões de Fundamentos Específicos
          */
-        $fundamental[] = Permission::updateOrCreate(['id' => 16], ['name' => 'create-specific-fundamental']);
-        $fundamental[] = Permission::updateOrCreate(['id' => 17], ['name' => 'edit-specific-fundamental']);
-        $fundamental[] = Permission::updateOrCreate(['id' => 18], ['name' => 'list-specific-fundamental']);
-        $fundamental[] = Permission::updateOrCreate(['id' => 19], ['name' => 'list-specifics-fundamental']);
-        $fundamental[] = Permission::updateOrCreate(['id' => 20], ['name' => 'delete-specific-fundamental']);
+        $fundamental[] = Permission::updateOrCreate(['id' => 7], ['name' => 'edit-specific-fundamental']);
+        $fundamental[] = Permission::updateOrCreate(['id' => 8], ['name' => 'view-specific-fundamental']);
 
         /**
          * Permissões de Posições
          */
-        $position[] = Permission::updateOrCreate(['id' => 21], ['name' => 'create-position']);
-        $position[] = Permission::updateOrCreate(['id' => 22], ['name' => 'edit-position']);
-        $position[] = Permission::updateOrCreate(['id' => 23], ['name' => 'list-position']);
-        $position[] = Permission::updateOrCreate(['id' => 24], ['name' => 'list-positions']);
-        $position[] = Permission::updateOrCreate(['id' => 25], ['name' => 'delete-position']);
+        $position[] = Permission::updateOrCreate(['id' => 9], ['name' => 'edit-position']);
+        $position[] = Permission::updateOrCreate(['id' => 10], ['name' => 'view-position']);
 
         /**
          * Permissões de Funções
          */
-        Permission::updateOrCreate(['id' => 26], ['name' => 'list-role-administrador']);
-        $role[] = Permission::updateOrCreate(['id' => 27], ['name' => 'list-role-technician']);
-        $role[] = Permission::updateOrCreate(['id' => 28], ['name' => 'list-role-player']);
+        Permission::updateOrCreate(['id' => 11], ['name' => 'view-role-admin']);
+        $role[] = Permission::updateOrCreate(['id' => 12], ['name' => 'view-role-technician']);
+        $role[] = Permission::updateOrCreate(['id' => 13], ['name' => 'view-role-player']);
 
         /**
          * Permissões de Treinos
          */
-        $training[] = Permission::updateOrCreate(['id' => 29], ['name' => 'create-training']);
-        $training[] = Permission::updateOrCreate(['id' => 30], ['name' => 'edit-training']);
-        $training[] = Permission::updateOrCreate(['id' => 31], ['name' => 'list-training']);
-        $training[] = Permission::updateOrCreate(['id' => 32], ['name' => 'list-trainings']);
-        $training[] = Permission::updateOrCreate(['id' => 33], ['name' => 'delete-training']);
+        $training[] = Permission::updateOrCreate(['id' => 14], ['name' => 'edit-training']);
+        $training[] = Permission::updateOrCreate(['id' => 15], ['name' => 'view-training']);
 
         /**
          * Permissões de Configurações
          */
-        $config[] = Permission::updateOrCreate(['id' => 34], ['name' => 'edit-config']);
-        $config[] = Permission::updateOrCreate(['id' => 35], ['name' => 'list-config']);
+        $config[] = Permission::updateOrCreate(['id' => 16], ['name' => 'edit-config']);
+        $config[] = Permission::updateOrCreate(['id' => 17], ['name' => 'view-config']);
 
         /**
          * Permissões de Configurações de Treino
          */
-        $trainingConfig[] = Permission::updateOrCreate(['id' => 36], ['name' => 'edit-training-config']);
-        $trainingConfig[] = Permission::updateOrCreate(['id' => 37], ['name' => 'list-training-config']);
+        $trainingConfig[] = Permission::updateOrCreate(['id' => 18], ['name' => 'edit-training-config']);
+        $trainingConfig[] = Permission::updateOrCreate(['id' => 19], ['name' => 'view-training-config']);
 
         /**
          * Relacionando Permissões
@@ -127,17 +109,17 @@ class PermissionTableSeeder extends Seeder
         $this->sync($player, $config);
 
         /**
-         * Definir user como perfil de administrador
+         * Definir user como perfil de admin
          */
-        User::whereEmail(env('MAIL_FROM_ADDRESS'))->first()->assignRole('Administrador');
-        User::whereEmail(env('MAIL_FROM_ADMIN'))->first()->assignRole('Administrador');
+        User::whereEmail(env('MAIL_FROM_ADDRESS'))->first()->assignRole('admin');
+        User::whereEmail(env('MAIL_FROM_ADMIN'))->first()->assignRole('admin');
 
         /**
          * Definir user como perfil de técnico
          */
         if (env('APP_DEBUG')) {
-            User::whereEmail(env('MAIL_FROM_TEST_TECHNICIAN'))->first()->assignRole('Técnico');
-            User::whereEmail(env('MAIL_FROM_TEST_PLAYER'))->first()->assignRole('Jogador');
+            User::whereEmail(env('MAIL_FROM_TEST_TECHNICIAN'))->first()->assignRole('technician');
+            User::whereEmail(env('MAIL_FROM_TEST_PLAYER'))->first()->assignRole('player');
         }
     }
 

--- a/graphql/config/ConfigQuery.graphql
+++ b/graphql/config/ConfigQuery.graphql
@@ -1,4 +1,4 @@
-extend type Query {
+extend type Query @guard {
     "Find attribute by ID=1, there will always be only one configuration record"
     config(
         id: ID!

--- a/graphql/config/ConfigQuery.graphql
+++ b/graphql/config/ConfigQuery.graphql
@@ -3,5 +3,7 @@ extend type Query {
     config(
         id: ID!
         @eq
-    ): Config @find
+    ): Config
+        @can(ability: "view", resolved: true)
+        @find
 }

--- a/graphql/fundamental/FundamentalQuery.graphql
+++ b/graphql/fundamental/FundamentalQuery.graphql
@@ -4,7 +4,9 @@ extend type Query @guard {
     fundamental(
         id: ID!
         @eq
-    ): Fundamental @find
+    ): Fundamental
+        @can(ability: "view", resolved: true)
+        @find
 
     "List multiple fundamentals."
     fundamentals(
@@ -14,5 +16,7 @@ extend type Query @guard {
         "Filters by the fundamental's user_id."
         user_id: Int @where(operator: "eq", field: "user_id")
 
-    ): [Fundamental!]! @paginate(defaultCount: 10, maxCount: 100)
+    ): [Fundamental!]!
+        @can(ability: "view", resolved: true)
+        @paginate(defaultCount: 10, maxCount: 100)
 }

--- a/graphql/position/PositionQuery.graphql
+++ b/graphql/position/PositionQuery.graphql
@@ -1,4 +1,4 @@
-extend type Query {
+extend type Query @guard {
     
     "Find a single position by an identifying attribute"
     position(

--- a/graphql/position/PositionQuery.graphql
+++ b/graphql/position/PositionQuery.graphql
@@ -4,7 +4,11 @@ extend type Query {
     position(
         id: ID!
         @eq
-    ): Position @find
+        
+    ): Position 
+        @can(ability: "view", resolved: true)
+        @find
+        @softDeletes
 
     "List multiple positions."
     positions (
@@ -14,5 +18,7 @@ extend type Query {
         "Filters by the position's user_id."
         user_id: Int @where(operator: "eq", field: "user_id")
 
-    ): [Position!]! @paginate(defaultCount: 10, maxCount: 100)
+    ): [Position!]! 
+        @paginate(defaultCount: 10, maxCount: 100)
+        @can(ability: "view", resolved: true)
 }

--- a/graphql/specific-fundamental/SpecificFundamentalQuery.graphql
+++ b/graphql/specific-fundamental/SpecificFundamentalQuery.graphql
@@ -4,7 +4,9 @@ extend type Query @guard {
     specificFundamental(
         id: ID!
         @eq
-    ): SpecificFundamental @find
+    ): SpecificFundamental
+        @can(ability: "view", resolved: true)
+        @find
 
     "List multiple fundamentals."
     specificFundamentals(
@@ -14,5 +16,7 @@ extend type Query @guard {
         "Filters by the fundamental's user_id."
         user_id: Int @where(operator: "eq", field: "user_id")
 
-    ): [SpecificFundamental!]! @paginate(defaultCount: 10, maxCount: 100)
+    ): [SpecificFundamental!]!
+        @can(ability: "view", resolved: true)
+        @paginate(defaultCount: 10, maxCount: 100)
 }

--- a/graphql/team/TeamQuery.graphql
+++ b/graphql/team/TeamQuery.graphql
@@ -4,7 +4,9 @@ extend type Query @guard {
     team(
         id: ID!
         @eq
-    ): Team @find
+    ): Team
+        @can(ability: "view", resolved: true)
+        @find
 
     "List multiple teams."
     teams(
@@ -14,5 +16,7 @@ extend type Query @guard {
         "Filters by the team's user_id."
         user_id: Int @where(operator: "eq", field: "user_id")
 
-    ): [Team!]! @paginate(defaultCount: 10, maxCount: 100)
+    ): [Team!]!
+        @can(ability: "view", resolved: true)
+        @paginate(defaultCount: 10, maxCount: 100)
 }

--- a/graphql/training-config/TrainingConfigQuery.graphql
+++ b/graphql/training-config/TrainingConfigQuery.graphql
@@ -1,4 +1,4 @@
-extend type Query {
+extend type Query @guard {
     "Find attribute by ID=1, there will always be only one configuration record"
     trainingConfig(
         id: ID!

--- a/graphql/training-config/TrainingConfigQuery.graphql
+++ b/graphql/training-config/TrainingConfigQuery.graphql
@@ -3,5 +3,7 @@ extend type Query {
     trainingConfig(
         id: ID!
         @eq
-    ): TrainingConfig @find
+    ): TrainingConfig
+        @can(ability: "view", resolved: true)
+        @find
 }

--- a/graphql/training/TrainingQuery.graphql
+++ b/graphql/training/TrainingQuery.graphql
@@ -4,7 +4,9 @@ extend type Query @guard {
     training(
         id: ID!
         @eq
-    ): Training @find
+    ): Training
+        @can(ability: "view", resolved: true)
+        @find
 
     "List multiple trainings."
     trainings(        
@@ -20,5 +22,7 @@ extend type Query @guard {
         "Filters by the training's date."
         dateStart: String @where(operator: "eq", field: "date_start")
 
-    ): [Training!]! @paginate(defaultCount: 10, maxCount: 100)
+    ): [Training!]! 
+        @can(ability: "view", resolved: true)
+        @paginate(defaultCount: 10, maxCount: 100)
 }

--- a/graphql/user/UserQuery.graphql
+++ b/graphql/user/UserQuery.graphql
@@ -9,12 +9,16 @@ extend type Query {
 
       "Search by email address."
       email: String @eq @rules(apply: ["prohibits:id", "required_without:id", "email"])
-    ): User @find
+    ): User 
+        @can(ability: "view", resolved: true)
+        @find
 
     "List multiple users."
     users(
       "Filters by name. Accepts SQL LIKE wildcards `%` and `_`."
       name: String @where(operator: "like")
-    ): [User!]! @paginate(defaultCount: 10)
+    ): [User!]! 
+        @can(ability: "view", resolved: true)
+        @paginate(defaultCount: 10)
 }
 

--- a/graphql/user/UserQuery.graphql
+++ b/graphql/user/UserQuery.graphql
@@ -1,7 +1,7 @@
 "A datetime string with format `Y-m-d H:i:s`, e.g. `2018-05-23 13:43:32`."
 scalar DateTime @scalar(class: "Nuwave\\Lighthouse\\Schema\\Types\\Scalars\\DateTime")
 
-extend type Query {
+extend type Query @guard {
     "Find a single user by an identifying attribute."
     user(
       "Search by primary key."

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -14,6 +14,39 @@
         <testsuite name="FeatureTenant">
             <directory suffix="Test.php">./tests/Feature/Tenant</directory>
         </testsuite>
+        <testsuite name="ConfigTest">
+            <file>./tests/Feature/GraphQL/ConfigTest.php</file>
+        </testsuite>
+        <testsuite name="FundamentalTest">
+            <file>./tests/Feature/GraphQL/FundamentalTest.php</file>
+        </testsuite>
+        <testsuite name="NotificationTest">
+            <file>./tests/Feature/GraphQL/NotificationTest.php</file>
+        </testsuite>
+        <testsuite name="PositionTest">
+            <file>./tests/Feature/GraphQL/PositionTest.php</file>
+        </testsuite>
+        <testsuite name="RoleTest">
+            <file>./tests/Feature/GraphQL/RoleTest.php</file>
+        </testsuite>
+        <testsuite name="SanctumTest">
+            <file>./tests/Feature/GraphQL/SanctumTest.php</file>
+        </testsuite>
+        <testsuite name="SpecificFundamentalTest">
+            <file>./tests/Feature/GraphQL/SpecificFundamentalTest.php</file>
+        </testsuite>
+        <testsuite name="TeamTest">
+            <file>./tests/Feature/GraphQL/TeamTest.php</file>
+        </testsuite>
+        <testsuite name="TrainingConfigTest">
+            <file>./tests/Feature/GraphQL/TrainingConfigTest.php</file>
+        </testsuite>
+        <testsuite name="TrainingTest">
+            <file>./tests/Feature/GraphQL/TrainingTest.php</file>
+        </testsuite>
+        <testsuite name="UserTest">
+            <file>./tests/Feature/GraphQL/UserTest.php</file>
+        </testsuite>
     </testsuites>
     <coverage processUncoveredFiles="true">
         <include>

--- a/tests/Feature/GraphQL/ConfigTest.php
+++ b/tests/Feature/GraphQL/ConfigTest.php
@@ -61,7 +61,7 @@ class ConfigTest extends TestCase
             $expectedMessage
         );
 
-        if($permission) {
+        if ($permission) {
             $response
                 ->assertJsonStructure($expected)
                 ->assertStatus(200);

--- a/tests/Feature/GraphQL/ConfigTest.php
+++ b/tests/Feature/GraphQL/ConfigTest.php
@@ -73,8 +73,6 @@ class ConfigTest extends TestCase
      */
     public function infoProvider()
     {
-        $configEdit = ['configEdit'];
-
         return [
             'with permission' => [
                 'type_message_error' => false,
@@ -91,7 +89,6 @@ class ConfigTest extends TestCase
                 'expected_message' => $this->unauthorized,
                 'expected' => [
                     'errors' => $this->errors,
-                    'data' => $configEdit,
                 ],
                 'permission' => false,
             ],

--- a/tests/Feature/GraphQL/ConfigTest.php
+++ b/tests/Feature/GraphQL/ConfigTest.php
@@ -13,7 +13,7 @@ class ConfigTest extends TestCase
 
     protected $login = true;
 
-    private $permission = 'Técnico';
+    private $permission = 'technician';
 
     private $data = [
         'id',

--- a/tests/Feature/GraphQL/ConfigTest.php
+++ b/tests/Feature/GraphQL/ConfigTest.php
@@ -13,7 +13,7 @@ class ConfigTest extends TestCase
 
     protected $login = true;
 
-    private $permission = 'technician';
+    private $role = 'technician';
 
     private $data = [
         'id',
@@ -23,6 +23,12 @@ class ConfigTest extends TestCase
         'createdAt',
         'updatedAt',
     ];
+
+    private function setPermissions(bool $hasPermission)
+    {
+        $this->checkPermission($hasPermission, $this->role, 'edit-config');
+        $this->checkPermission($hasPermission, $this->role, 'view-config');
+    }
 
     /**
      * Listagem de configurações.
@@ -39,10 +45,9 @@ class ConfigTest extends TestCase
         $typeMessageError,
         $expectedMessage,
         $expected,
-        bool $permission
+        bool $hasPermission
     ) {
-        $this->checkPermission($permission, $this->permission, 'edit-config');
-        $this->checkPermission($permission, $this->permission, 'view-config');
+        $this->setPermissions($hasPermission);
 
         $response = $this->graphQL(
             'config',
@@ -57,11 +62,11 @@ class ConfigTest extends TestCase
         $this->assertMessageError(
             $typeMessageError,
             $response,
-            $permission,
+            $hasPermission,
             $expectedMessage
         );
 
-        if ($permission) {
+        if ($hasPermission) {
             $response
                 ->assertJsonStructure($expected)
                 ->assertStatus(200);
@@ -111,9 +116,9 @@ class ConfigTest extends TestCase
         $typeMessageError,
         $expectedMessage,
         $expected,
-        bool $permission
+        bool $hasPermission
     ) {
-        $this->checkPermission($permission, $this->permission, 'edit-config');
+        $this->setPermissions($hasPermission);
 
         $parameters['id'] = 1;
 
@@ -129,7 +134,7 @@ class ConfigTest extends TestCase
         $this->assertMessageError(
             $typeMessageError,
             $response,
-            $permission,
+            $hasPermission,
             $expectedMessage
         );
 

--- a/tests/Feature/GraphQL/ConfigTest.php
+++ b/tests/Feature/GraphQL/ConfigTest.php
@@ -87,7 +87,7 @@ class ConfigTest extends TestCase
                         'config' => $this->data,
                     ],
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'without permission' => [
                 'type_message_error' => 'message',
@@ -95,7 +95,7 @@ class ConfigTest extends TestCase
                 'expected' => [
                     'errors' => $this->errors,
                 ],
-                'permission' => false,
+                'hasPermission' => false,
             ],
         ];
     }
@@ -165,7 +165,7 @@ class ConfigTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $configEdit,
                 ],
-                'permission' => false,
+                'hasPermission' => false,
             ],
             'edit config, success' => [
                 [
@@ -180,7 +180,7 @@ class ConfigTest extends TestCase
                         'configEdit' => $this->data,
                     ],
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'nameTenant field is required, expected error' => [
                 [
@@ -193,7 +193,7 @@ class ConfigTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $configEdit,
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'nameTenant field is min 3 characteres, expected error' => [
                 [
@@ -206,7 +206,7 @@ class ConfigTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $configEdit,
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
         ];
     }

--- a/tests/Feature/GraphQL/FundamentalTest.php
+++ b/tests/Feature/GraphQL/FundamentalTest.php
@@ -200,7 +200,6 @@ class FundamentalTest extends TestCase
         $expected,
         $hasPermission
         ) {
-        
         $this->setPermissions($hasPermission);
 
         $response = $this->graphQL(
@@ -436,13 +435,12 @@ class FundamentalTest extends TestCase
      * @return void
      */
     public function fundamentalDelete(
-        $data, 
-        $typeMessageError, 
-        $expectedMessage, 
-        $expected, 
+        $data,
+        $typeMessageError,
+        $expectedMessage,
+        $expected,
         $hasPermission
-    )
-    {
+    ) {
         $this->login = true;
 
         $this->setPermissions($hasPermission);

--- a/tests/Feature/GraphQL/FundamentalTest.php
+++ b/tests/Feature/GraphQL/FundamentalTest.php
@@ -99,7 +99,7 @@ class FundamentalTest extends TestCase
                         ],
                     ],
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'without permission' => [
                 'type_message_error' => 'message',
@@ -107,7 +107,7 @@ class FundamentalTest extends TestCase
                 'expected' => [
                     'errors' => $this->errors,
                 ],
-                'permission' => false,
+                'hasPermission' => false,
             ],
         ];
     }
@@ -171,7 +171,7 @@ class FundamentalTest extends TestCase
                         'fundamental' => $this->data,
                     ],
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'without permission' => [
                 'type_message_error' => 'message',
@@ -179,7 +179,7 @@ class FundamentalTest extends TestCase
                 'expected' => [
                     'errors' => $this->errors,
                 ],
-                'permission' => false,
+                'hasPermission' => false,
             ],
         ];
     }
@@ -242,7 +242,7 @@ class FundamentalTest extends TestCase
                         'fundamentalCreate' => $this->data,
                     ],
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'create fundamental without permission, expected error' => [
                 [
@@ -255,7 +255,7 @@ class FundamentalTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $fundamentalCreate,
                 ],
-                'permission' => false,
+                'hasPermission' => false,
             ],
             'name field is not unique, expected error' => [
                 [
@@ -268,7 +268,7 @@ class FundamentalTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $fundamentalCreate,
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'name field is required, expected error' => [
                 [
@@ -281,7 +281,7 @@ class FundamentalTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $fundamentalCreate,
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'name field is min 3 characteres, expected error' => [
                 [
@@ -294,7 +294,7 @@ class FundamentalTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $fundamentalCreate,
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
         ];
     }
@@ -367,7 +367,7 @@ class FundamentalTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $fundamentalEdit,
                 ],
-                'permission' => false,
+                'hasPermission' => false,
             ],
             'edit fundamental, success' => [
                 [
@@ -381,7 +381,7 @@ class FundamentalTest extends TestCase
                         'fundamentalEdit' => $this->data,
                     ],
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'name field is not unique, expected error' => [
                 [
@@ -393,7 +393,7 @@ class FundamentalTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $fundamentalEdit,
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'name field is required, expected error' => [
                 [
@@ -406,7 +406,7 @@ class FundamentalTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $fundamentalEdit,
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'name field is min 3 characteres, expected error' => [
                 [
@@ -419,7 +419,7 @@ class FundamentalTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $fundamentalEdit,
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
         ];
     }
@@ -493,7 +493,7 @@ class FundamentalTest extends TestCase
                         'fundamentalDelete' => [$this->data],
                     ],
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'delete fundamental without permission, expected error' => [
                 [
@@ -505,7 +505,7 @@ class FundamentalTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $fundamentalDelete,
                 ],
-                'permission' => false,
+                'hasPermission' => false,
             ],
             'delete fundamental that does not exist, expected error' => [
                 [
@@ -517,7 +517,7 @@ class FundamentalTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $fundamentalDelete,
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
         ];
     }

--- a/tests/Feature/GraphQL/FundamentalTest.php
+++ b/tests/Feature/GraphQL/FundamentalTest.php
@@ -70,15 +70,16 @@ class FundamentalTest extends TestCase
 
         if ($permission) {
             $response
-                ->assertJsonStructure(
-                    ['data' => [
+                ->assertJsonStructure([
+                    'data' => [
                         'fundamentals' => [
                             'paginatorInfo' => $this->paginatorInfo,
                             'data' => [
                                 '*' => $this->data,
                             ],
-                        ]]]
-                )
+                        ]
+                    ]
+                ])
                 ->assertStatus(200);
         }
     }

--- a/tests/Feature/GraphQL/FundamentalTest.php
+++ b/tests/Feature/GraphQL/FundamentalTest.php
@@ -14,7 +14,7 @@ class FundamentalTest extends TestCase
 
     protected $login = true;
 
-    private $permission = 'Técnico';
+    private $permission = 'technician';
 
     private $data = [
         'id',
@@ -107,7 +107,7 @@ class FundamentalTest extends TestCase
         $expected,
         $permission
         ) {
-        $this->checkPermission($permission, $this->permission, 'create-fundamental');
+        $this->checkPermission($permission, $this->permission, 'edit-fundamental');
 
         $response = $this->graphQL(
             'fundamentalCreate',
@@ -345,7 +345,7 @@ class FundamentalTest extends TestCase
     {
         $this->login = true;
 
-        $this->checkPermission($permission, $this->permission, 'delete-fundamental');
+        $this->checkPermission($permission, $this->permission, 'edit-fundamental');
 
         $fundamental = Fundamental::factory()->make();
         $fundamental->save();

--- a/tests/Feature/GraphQL/FundamentalTest.php
+++ b/tests/Feature/GraphQL/FundamentalTest.php
@@ -14,7 +14,7 @@ class FundamentalTest extends TestCase
 
     protected $login = true;
 
-    private $permission = 'technician';
+    private $role = 'technician';
 
     private $data = [
         'id',
@@ -23,6 +23,12 @@ class FundamentalTest extends TestCase
         'createdAt',
         'updatedAt',
     ];
+
+    private function setPermissions(bool $hasPermission)
+    {
+        $this->checkPermission($hasPermission, $this->role, 'edit-fundamental');
+        $this->checkPermission($hasPermission, $this->role, 'view-fundamental');
+    }
 
     /**
      * Listagem de todos os fundamentos.
@@ -39,12 +45,11 @@ class FundamentalTest extends TestCase
         $typeMessageError,
         $expectedMessage,
         $expected,
-        bool $permission
+        bool $hasPermission
     ) {
-        Fundamental::factory()->make()->save();
+        $this->setPermissions($hasPermission);
 
-        $this->checkPermission($permission, $this->permission, 'edit-fundamental');
-        $this->checkPermission($permission, $this->permission, 'view-fundamental');
+        Fundamental::factory()->make()->save();
 
         $response = $this->graphQL(
             'fundamentals',
@@ -64,11 +69,11 @@ class FundamentalTest extends TestCase
         $this->assertMessageError(
             $typeMessageError,
             $response,
-            $permission,
+            $hasPermission,
             $expectedMessage
         );
 
-        if ($permission) {
+        if ($hasPermission) {
             $response
                 ->assertJsonStructure($expected)
                 ->assertStatus(200);
@@ -122,13 +127,12 @@ class FundamentalTest extends TestCase
         $typeMessageError,
         $expectedMessage,
         $expected,
-        bool $permission
+        bool $hasPermission
     ) {
+        $this->setPermissions($hasPermission);
+
         $fundamental = Fundamental::factory()->make();
         $fundamental->save();
-
-        $this->checkPermission($permission, $this->permission, 'edit-fundamental');
-        $this->checkPermission($permission, $this->permission, 'view-fundamental');
 
         $response = $this->graphQL(
             'fundamental',
@@ -143,16 +147,13 @@ class FundamentalTest extends TestCase
         $this->assertMessageError(
             $typeMessageError,
             $response,
-            $permission,
+            $hasPermission,
             $expectedMessage
         );
 
-        if ($permission) {
-            $response->assertJsonStructure([
-                'data' => [
-                    'fundamental' => $this->data,
-                ],
-            ])->assertStatus(200);
+        if ($hasPermission) {
+            $response->assertJsonStructure($expected)
+                ->assertStatus(200);
         }
     }
 
@@ -167,7 +168,7 @@ class FundamentalTest extends TestCase
                 'expected_message' => false,
                 'expected' => [
                     'data' => [
-                        'config' => $this->data,
+                        'fundamental' => $this->data,
                     ],
                 ],
                 'permission' => true,
@@ -197,9 +198,10 @@ class FundamentalTest extends TestCase
         $typeMessageError,
         $expectedMessage,
         $expected,
-        $permission
+        $hasPermission
         ) {
-        $this->checkPermission($permission, $this->permission, 'edit-fundamental');
+        
+        $this->setPermissions($hasPermission);
 
         $response = $this->graphQL(
             'fundamentalCreate',
@@ -210,7 +212,7 @@ class FundamentalTest extends TestCase
             true
         );
 
-        $this->assertMessageError($typeMessageError, $response, $permission, $expectedMessage);
+        $this->assertMessageError($typeMessageError, $response, $hasPermission, $expectedMessage);
 
         $response
             ->assertJsonStructure($expected)
@@ -313,9 +315,9 @@ class FundamentalTest extends TestCase
         $typeMessageError,
         $expectedMessage,
         $expected,
-        $permission
+        $hasPermission
         ) {
-        $this->checkPermission($permission, $this->permission, 'edit-fundamental');
+        $this->setPermissions($hasPermission);
 
         $fundamentalExist = Fundamental::factory()->make();
         $fundamentalExist->save();
@@ -337,7 +339,7 @@ class FundamentalTest extends TestCase
             true
         );
 
-        $this->assertMessageError($typeMessageError, $response, $permission, $expectedMessage);
+        $this->assertMessageError($typeMessageError, $response, $hasPermission, $expectedMessage);
 
         $response
             ->assertJsonStructure($expected)
@@ -433,11 +435,17 @@ class FundamentalTest extends TestCase
      *
      * @return void
      */
-    public function fundamentalDelete($data, $typeMessageError, $expectedMessage, $expected, $permission)
+    public function fundamentalDelete(
+        $data, 
+        $typeMessageError, 
+        $expectedMessage, 
+        $expected, 
+        $hasPermission
+    )
     {
         $this->login = true;
 
-        $this->checkPermission($permission, $this->permission, 'edit-fundamental');
+        $this->setPermissions($hasPermission);
 
         $fundamental = Fundamental::factory()->make();
         $fundamental->save();
@@ -457,7 +465,7 @@ class FundamentalTest extends TestCase
             true
         );
 
-        $this->assertMessageError($typeMessageError, $response, $permission, $expectedMessage);
+        $this->assertMessageError($typeMessageError, $response, $hasPermission, $expectedMessage);
 
         $response
             ->assertJsonStructure($expected)

--- a/tests/Feature/GraphQL/FundamentalTest.php
+++ b/tests/Feature/GraphQL/FundamentalTest.php
@@ -70,16 +70,7 @@ class FundamentalTest extends TestCase
 
         if ($permission) {
             $response
-                ->assertJsonStructure([
-                    'data' => [
-                        'fundamentals' => [
-                            'paginatorInfo' => $this->paginatorInfo,
-                            'data' => [
-                                '*' => $this->data,
-                            ],
-                        ]
-                    ]
-                ])
+                ->assertJsonStructure($expected)
                 ->assertStatus(200);
         }
     }
@@ -95,8 +86,13 @@ class FundamentalTest extends TestCase
                 'expected_message' => false,
                 'expected' => [
                     'data' => [
-                        'fundamentals' => $this->data,
-                    ],
+                        'fundamentals' => [
+                            'paginatorInfo' => $this->paginatorInfo,
+                            'data' => [
+                                '*' => $this->data,
+                            ],
+                        ]
+                    ]
                 ],
                 'permission' => true,
             ],

--- a/tests/Feature/GraphQL/FundamentalTest.php
+++ b/tests/Feature/GraphQL/FundamentalTest.php
@@ -91,8 +91,8 @@ class FundamentalTest extends TestCase
                             'data' => [
                                 '*' => $this->data,
                             ],
-                        ]
-                    ]
+                        ],
+                    ],
                 ],
                 'permission' => true,
             ],

--- a/tests/Feature/GraphQL/FundamentalTest.php
+++ b/tests/Feature/GraphQL/FundamentalTest.php
@@ -117,8 +117,6 @@ class FundamentalTest extends TestCase
      */
     public function infoProvider()
     {
-        $configEdit = ['configEdit'];
-
         return [
             'with permission' => [
                 'type_message_error' => false,
@@ -135,7 +133,6 @@ class FundamentalTest extends TestCase
                 'expected_message' => $this->unauthorized,
                 'expected' => [
                     'errors' => $this->errors,
-                    'data' => $configEdit,
                 ],
                 'permission' => false,
             ],

--- a/tests/Feature/GraphQL/PositionTest.php
+++ b/tests/Feature/GraphQL/PositionTest.php
@@ -24,7 +24,7 @@ class PositionTest extends TestCase
         'updatedAt',
     ];
 
-    private function setPermissions (bool $hasPermission)
+    private function setPermissions(bool $hasPermission)
     {
         $this->checkPermission($hasPermission, $this->role, 'edit-position');
         $this->checkPermission($hasPermission, $this->role, 'view-position');
@@ -131,7 +131,6 @@ class PositionTest extends TestCase
     ) {
         $this->setPermissions($hasPermission);
 
-
         $position = Position::factory()->make();
         $position->save();
 
@@ -204,7 +203,6 @@ class PositionTest extends TestCase
         $expected,
         bool $hasPermission
         ) {
-
         $this->checkPermission($hasPermission, $this->role, 'edit-position');
 
         $response = $this->graphQL(
@@ -440,9 +438,9 @@ class PositionTest extends TestCase
      * @return void
      */
     public function positionDelete(
-        $data, 
-        $typeMessageError, 
-        $expectedMessage, 
+        $data,
+        $typeMessageError,
+        $expectedMessage,
         $expected,
         bool $hasPermission)
     {
@@ -469,9 +467,9 @@ class PositionTest extends TestCase
         );
 
         $this->assertMessageError(
-            $typeMessageError, 
-            $response, 
-            $hasPermission, 
+            $typeMessageError,
+            $response,
+            $hasPermission,
             $expectedMessage
         );
 

--- a/tests/Feature/GraphQL/PositionTest.php
+++ b/tests/Feature/GraphQL/PositionTest.php
@@ -68,7 +68,7 @@ class PositionTest extends TestCase
      * @author Maicon Cerutti
      *
      * @test
-     * 
+     *
      * @dataProvider infoProvider
      *
      * @return void
@@ -78,8 +78,7 @@ class PositionTest extends TestCase
         $expectedMessage,
         $expected,
         bool $permission
-    )
-    {
+    ) {
         $this->checkPermission($permission, $this->permission, 'edit-position');
         $this->checkPermission($permission, $this->permission, 'view-position');
 

--- a/tests/Feature/GraphQL/PositionTest.php
+++ b/tests/Feature/GraphQL/PositionTest.php
@@ -173,7 +173,7 @@ class PositionTest extends TestCase
                         'position' => $this->data,
                     ],
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'without permission' => [
                 'type_message_error' => 'message',
@@ -181,7 +181,7 @@ class PositionTest extends TestCase
                 'expected' => [
                     'errors' => $this->errors,
                 ],
-                'permission' => false,
+                'hasPermission' => false,
             ],
         ];
     }
@@ -246,7 +246,7 @@ class PositionTest extends TestCase
                         'positionCreate' => $this->data,
                     ],
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'create position without permission, expected error' => [
                 [
@@ -259,7 +259,7 @@ class PositionTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $positionCreate,
                 ],
-                'permission' => false,
+                'hasPermission' => false,
             ],
             'name field is not unique, expected error' => [
                 [
@@ -272,7 +272,7 @@ class PositionTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $positionCreate,
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'name field is required, expected error' => [
                 [
@@ -285,7 +285,7 @@ class PositionTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $positionCreate,
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'name field is min 3 characteres, expected error' => [
                 [
@@ -298,7 +298,7 @@ class PositionTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $positionCreate,
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
         ];
     }
@@ -371,7 +371,7 @@ class PositionTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $positionEdit,
                 ],
-                'permission' => false,
+                'hasPermission' => false,
             ],
             'edit position, success' => [
                 [
@@ -385,7 +385,7 @@ class PositionTest extends TestCase
                         'positionEdit' => $this->data,
                     ],
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'name field is not unique, expected error' => [
                 [
@@ -397,7 +397,7 @@ class PositionTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $positionEdit,
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'name field is required, expected error' => [
                 [
@@ -410,7 +410,7 @@ class PositionTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $positionEdit,
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'name field is min 3 characteres, expected error' => [
                 [
@@ -423,7 +423,7 @@ class PositionTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $positionEdit,
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
         ];
     }
@@ -501,7 +501,7 @@ class PositionTest extends TestCase
                         'positionDelete' => [$this->data],
                     ],
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'delete position without permission, expected error' => [
                 [
@@ -513,7 +513,7 @@ class PositionTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $positionDelete,
                 ],
-                'permission' => false,
+                'hasPermission' => false,
             ],
             'delete position that does not exist, expected error' => [
                 [
@@ -525,7 +525,7 @@ class PositionTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $positionDelete,
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
         ];
     }

--- a/tests/Feature/GraphQL/PositionTest.php
+++ b/tests/Feature/GraphQL/PositionTest.php
@@ -14,7 +14,7 @@ class PositionTest extends TestCase
 
     protected $login = true;
 
-    private $permission = 'technician';
+    private $role = 'technician';
 
     private $data = [
         'id',
@@ -23,6 +23,12 @@ class PositionTest extends TestCase
         'createdAt',
         'updatedAt',
     ];
+
+    private function setPermissions (bool $hasPermission)
+    {
+        $this->checkPermission($hasPermission, $this->role, 'edit-position');
+        $this->checkPermission($hasPermission, $this->role, 'view-position');
+    }
 
     /**
      * Listagem de todos os fundamentos.
@@ -39,12 +45,11 @@ class PositionTest extends TestCase
         $typeMessageError,
         $expectedMessage,
         $expected,
-        bool $permission
+        bool $hasPermission
     ) {
-        Position::factory()->make()->save();
+        $this->setPermissions($hasPermission);
 
-        $this->checkPermission($permission, $this->permission, 'edit-position');
-        $this->checkPermission($permission, $this->permission, 'view-position');
+        Position::factory()->make()->save();
 
         $response = $this->graphQL(
             'positions',
@@ -64,11 +69,11 @@ class PositionTest extends TestCase
         $this->assertMessageError(
             $typeMessageError,
             $response,
-            $permission,
+            $hasPermission,
             $expectedMessage
         );
 
-        if ($permission) {
+        if ($hasPermission) {
             $response
                 ->assertJsonStructure($expected)
                 ->assertStatus(200);
@@ -94,7 +99,7 @@ class PositionTest extends TestCase
                         ],
                     ],
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'without permission' => [
                 'type_message_error' => 'message',
@@ -102,7 +107,7 @@ class PositionTest extends TestCase
                 'expected' => [
                     'errors' => $this->errors,
                 ],
-                'permission' => false,
+                'hasPermission' => false,
             ],
         ];
     }
@@ -122,10 +127,10 @@ class PositionTest extends TestCase
         $typeMessageError,
         $expectedMessage,
         $expected,
-        bool $permission
+        bool $hasPermission
     ) {
-        $this->checkPermission($permission, $this->permission, 'edit-position');
-        $this->checkPermission($permission, $this->permission, 'view-position');
+        $this->setPermissions($hasPermission);
+
 
         $position = Position::factory()->make();
         $position->save();
@@ -143,11 +148,11 @@ class PositionTest extends TestCase
         $this->assertMessageError(
             $typeMessageError,
             $response,
-            $permission,
+            $hasPermission,
             $expectedMessage
         );
 
-        if ($permission) {
+        if ($hasPermission) {
             $response
                 ->assertJsonStructure($expected)
                 ->assertStatus(200);
@@ -197,9 +202,10 @@ class PositionTest extends TestCase
         $typeMessageError,
         $expectedMessage,
         $expected,
-        $permission
+        bool $hasPermission
         ) {
-        $this->checkPermission($permission, $this->permission, 'edit-position');
+
+        $this->checkPermission($hasPermission, $this->role, 'edit-position');
 
         $response = $this->graphQL(
             'positionCreate',
@@ -210,7 +216,7 @@ class PositionTest extends TestCase
             true
         );
 
-        $this->assertMessageError($typeMessageError, $response, $permission, $expectedMessage);
+        $this->assertMessageError($typeMessageError, $response, $hasPermission, $expectedMessage);
 
         $response
             ->assertJsonStructure($expected)
@@ -313,9 +319,9 @@ class PositionTest extends TestCase
         $typeMessageError,
         $expectedMessage,
         $expected,
-        $permission
+        bool $hasPermission
         ) {
-        $this->checkPermission($permission, $this->permission, 'edit-position');
+        $this->checkPermission($hasPermission, $this->role, 'edit-position');
 
         $positionExist = Position::factory()->make();
         $positionExist->save();
@@ -337,7 +343,7 @@ class PositionTest extends TestCase
             true
         );
 
-        $this->assertMessageError($typeMessageError, $response, $permission, $expectedMessage);
+        $this->assertMessageError($typeMessageError, $response, $hasPermission, $expectedMessage);
 
         $response
             ->assertJsonStructure($expected)
@@ -433,11 +439,16 @@ class PositionTest extends TestCase
      *
      * @return void
      */
-    public function positionDelete($data, $typeMessageError, $expectedMessage, $expected, $permission)
+    public function positionDelete(
+        $data, 
+        $typeMessageError, 
+        $expectedMessage, 
+        $expected,
+        bool $hasPermission)
     {
         $this->login = true;
 
-        $this->checkPermission($permission, $this->permission, 'edit-position');
+        $this->checkPermission($hasPermission, $this->role, 'edit-position');
 
         $position = Position::factory()->make();
         $position->save();
@@ -457,7 +468,12 @@ class PositionTest extends TestCase
             true
         );
 
-        $this->assertMessageError($typeMessageError, $response, $permission, $expectedMessage);
+        $this->assertMessageError(
+            $typeMessageError, 
+            $response, 
+            $hasPermission, 
+            $expectedMessage
+        );
 
         $response
             ->assertJsonStructure($expected)

--- a/tests/Feature/GraphQL/PositionTest.php
+++ b/tests/Feature/GraphQL/PositionTest.php
@@ -30,7 +30,7 @@ class PositionTest extends TestCase
      * @author Maicon Cerutti
      *
      * @test
-     * 
+     *
      * @dataProvider listProvider
      *
      * @return void
@@ -40,8 +40,7 @@ class PositionTest extends TestCase
         $expectedMessage,
         $expected,
         bool $permission
-    )
-    {
+    ) {
         Position::factory()->make()->save();
 
         $this->checkPermission($permission, $this->permission, 'edit-position');

--- a/tests/Feature/GraphQL/PositionTest.php
+++ b/tests/Feature/GraphQL/PositionTest.php
@@ -442,7 +442,8 @@ class PositionTest extends TestCase
         $typeMessageError,
         $expectedMessage,
         $expected,
-        bool $hasPermission)
+        bool $hasPermission
+    )
     {
         $this->login = true;
 

--- a/tests/Feature/GraphQL/PositionTest.php
+++ b/tests/Feature/GraphQL/PositionTest.php
@@ -14,7 +14,7 @@ class PositionTest extends TestCase
 
     protected $login = true;
 
-    private $permission = 'Técnico';
+    private $permission = 'technician';
 
     private $data = [
         'id',
@@ -109,7 +109,7 @@ class PositionTest extends TestCase
         $expected,
         $permission
         ) {
-        $this->checkPermission($permission, $this->permission, 'create-position');
+        $this->checkPermission($permission, $this->permission, 'edit-position');
 
         $response = $this->graphQL(
             'positionCreate',
@@ -347,7 +347,7 @@ class PositionTest extends TestCase
     {
         $this->login = true;
 
-        $this->checkPermission($permission, $this->permission, 'delete-position');
+        $this->checkPermission($permission, $this->permission, 'edit-position');
 
         $position = Position::factory()->make();
         $position->save();

--- a/tests/Feature/GraphQL/RoleTest.php
+++ b/tests/Feature/GraphQL/RoleTest.php
@@ -26,7 +26,7 @@ class RoleTest extends TestCase
      *
      * @return void
      */
-    public function rolInfo()
+    public function roleInfo()
     {
         $this->login = true;
 

--- a/tests/Feature/GraphQL/SpecificFundamentalTest.php
+++ b/tests/Feature/GraphQL/SpecificFundamentalTest.php
@@ -100,7 +100,7 @@ class SpecificFundamentalTest extends TestCase
                         ],
                     ],
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'without permission' => [
                 'type_message_error' => 'message',
@@ -108,7 +108,7 @@ class SpecificFundamentalTest extends TestCase
                 'expected' => [
                     'errors' => $this->errors,
                 ],
-                'permission' => false,
+                'hasPermission' => false,
             ],
         ];
     }
@@ -172,7 +172,7 @@ class SpecificFundamentalTest extends TestCase
                         'specificFundamental' => $this->data,
                     ],
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'without permission' => [
                 'type_message_error' => 'message',
@@ -180,7 +180,7 @@ class SpecificFundamentalTest extends TestCase
                 'expected' => [
                     'errors' => $this->errors,
                 ],
-                'permission' => false,
+                'hasPermission' => false,
             ],
         ];
     }
@@ -252,7 +252,7 @@ class SpecificFundamentalTest extends TestCase
                         'specificFundamentalCreate' => $this->data,
                     ],
                 ],
-                'permission' => true,
+                'hasPermission' => true,
                 'add_relationship' => true,
             ],
             'create specific fundamental, no relationship, success' => [
@@ -267,7 +267,7 @@ class SpecificFundamentalTest extends TestCase
                         'specificFundamentalCreate' => $this->data,
                     ],
                 ],
-                'permission' => true,
+                'hasPermission' => true,
                 'add_relationship' => false,
             ],
             'create specific fundamental without permission, expected error' => [
@@ -281,7 +281,7 @@ class SpecificFundamentalTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $specificFundamentalCreate,
                 ],
-                'permission' => false,
+                'hasPermission' => false,
                 'add_relationship' => false,
             ],
             'name field is not unique, expected error' => [
@@ -295,7 +295,7 @@ class SpecificFundamentalTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $specificFundamentalCreate,
                 ],
-                'permission' => true,
+                'hasPermission' => true,
                 'add_relationship' => false,
             ],
             'name field is required, expected error' => [
@@ -309,7 +309,7 @@ class SpecificFundamentalTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $specificFundamentalCreate,
                 ],
-                'permission' => true,
+                'hasPermission' => true,
                 'add_relationship' => false,
             ],
             'name field is min 3 characteres, expected error' => [
@@ -323,7 +323,7 @@ class SpecificFundamentalTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $specificFundamentalCreate,
                 ],
-                'permission' => true,
+                'hasPermission' => true,
                 'add_relationship' => false,
             ],
         ];
@@ -405,7 +405,7 @@ class SpecificFundamentalTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $fundamentalEdit,
                 ],
-                'permission' => false,
+                'hasPermission' => false,
                 'add_relationship' => false,
             ],
             'edit specific fundamental, no relationship, success' => [
@@ -420,7 +420,7 @@ class SpecificFundamentalTest extends TestCase
                         'specificFundamentalEdit' => $this->data,
                     ],
                 ],
-                'permission' => true,
+                'hasPermission' => true,
                 'add_relationship' => false,
             ],
             'edit specific fundamental, with relationship, success' => [
@@ -435,7 +435,7 @@ class SpecificFundamentalTest extends TestCase
                         'specificFundamentalEdit' => $this->data,
                     ],
                 ],
-                'permission' => true,
+                'hasPermission' => true,
                 'add_relationship' => true,
             ],
             'name field is not unique, expected error' => [
@@ -448,7 +448,7 @@ class SpecificFundamentalTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $fundamentalEdit,
                 ],
-                'permission' => true,
+                'hasPermission' => true,
                 'add_relationship' => false,
             ],
             'name field is required, expected error' => [
@@ -462,7 +462,7 @@ class SpecificFundamentalTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $fundamentalEdit,
                 ],
-                'permission' => true,
+                'hasPermission' => true,
                 'add_relationship' => false,
             ],
             'name field is min 3 characteres, expected error' => [
@@ -476,7 +476,7 @@ class SpecificFundamentalTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $fundamentalEdit,
                 ],
-                'permission' => true,
+                'hasPermission' => true,
                 'add_relationship' => false,
             ],
         ];
@@ -543,7 +543,7 @@ class SpecificFundamentalTest extends TestCase
                         'specificFundamentalDelete' => [$this->data],
                     ],
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'delete specific fundamental without permission, expected error' => [
                 [
@@ -555,7 +555,7 @@ class SpecificFundamentalTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $specificFundamentalDelete,
                 ],
-                'permission' => false,
+                'hasPermission' => false,
             ],
             'delete specific fundamental that does not exist, expected error' => [
                 [
@@ -567,7 +567,7 @@ class SpecificFundamentalTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $specificFundamentalDelete,
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
         ];
     }

--- a/tests/Feature/GraphQL/SpecificFundamentalTest.php
+++ b/tests/Feature/GraphQL/SpecificFundamentalTest.php
@@ -15,7 +15,7 @@ class SpecificFundamentalTest extends TestCase
 
     protected $login = true;
 
-    private $permission = 'Técnico';
+    private $permission = 'technician';
 
     private $data = [
         'id',
@@ -111,7 +111,7 @@ class SpecificFundamentalTest extends TestCase
         $permission,
         $addRelationship
         ) {
-        $this->checkPermission($permission, $this->permission, 'create-specific-fundamental');
+        $this->checkPermission($permission, $this->permission, 'edit-specific-fundamental');
 
         $fundamental = Fundamental::factory()->make();
         $fundamental->save();
@@ -404,7 +404,7 @@ class SpecificFundamentalTest extends TestCase
     {
         $this->login = true;
 
-        $this->checkPermission($permission, $this->permission, 'delete-specific-fundamental');
+        $this->checkPermission($permission, $this->permission, 'edit-specific-fundamental');
 
         $specificFundamental = SpecificFundamental::factory()->make();
         $specificFundamental->save();

--- a/tests/Feature/GraphQL/SpecificFundamentalTest.php
+++ b/tests/Feature/GraphQL/SpecificFundamentalTest.php
@@ -31,7 +31,7 @@ class SpecificFundamentalTest extends TestCase
      * @author Maicon Cerutti
      *
      * @test
-     * 
+     *
      * @dataProvider listProvider
      *
      * @return void
@@ -41,8 +41,7 @@ class SpecificFundamentalTest extends TestCase
         $expectedMessage,
         $expected,
         bool $permission
-    )
-    {
+    ) {
         SpecificFundamental::factory()->make()->save();
 
         $this->checkPermission($permission, $this->permission, 'edit-specific-fundamental');
@@ -125,8 +124,7 @@ class SpecificFundamentalTest extends TestCase
         $expectedMessage,
         $expected,
         bool $permission
-    )
-    {
+    ) {
         $specificFundamental = SpecificFundamental::factory()->make();
         $specificFundamental->save();
 

--- a/tests/Feature/GraphQL/SpecificFundamentalTest.php
+++ b/tests/Feature/GraphQL/SpecificFundamentalTest.php
@@ -31,14 +31,24 @@ class SpecificFundamentalTest extends TestCase
      * @author Maicon Cerutti
      *
      * @test
+     * 
+     * @dataProvider listProvider
      *
      * @return void
      */
-    public function specificFundamentalsList()
+    public function specificFundamentalsList(
+        $typeMessageError,
+        $expectedMessage,
+        $expected,
+        bool $permission
+    )
     {
         SpecificFundamental::factory()->make()->save();
 
-        $this->graphQL(
+        $this->checkPermission($permission, $this->permission, 'edit-specific-fundamental');
+        $this->checkPermission($permission, $this->permission, 'view-specific-fundamental');
+
+        $response = $this->graphQL(
             'specificFundamentals',
             [
                 'name' => '%%',
@@ -51,16 +61,52 @@ class SpecificFundamentalTest extends TestCase
             ],
             'query',
             false
-        )->assertJsonStructure([
-            'data' => [
-                'specificFundamentals' => [
-                    'paginatorInfo' => $this->paginatorInfo,
+        );
+
+        $this->assertMessageError(
+            $typeMessageError,
+            $response,
+            $permission,
+            $expectedMessage
+        );
+
+        if ($permission) {
+            $response
+                ->assertJsonStructure($expected)
+                ->assertStatus(200);
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function listProvider()
+    {
+        return [
+            'with permission' => [
+                'type_message_error' => false,
+                'expected_message' => false,
+                'expected' => [
                     'data' => [
-                        '*' => $this->data,
+                        'specificFundamentals' => [
+                            'paginatorInfo' => $this->paginatorInfo,
+                            'data' => [
+                                '*' => $this->data,
+                            ],
+                        ],
                     ],
                 ],
+                'permission' => true,
             ],
-        ])->assertStatus(200);
+            'without permission' => [
+                'type_message_error' => 'message',
+                'expected_message' => $this->unauthorized,
+                'expected' => [
+                    'errors' => $this->errors,
+                ],
+                'permission' => false,
+            ],
+        ];
     }
 
     /**
@@ -74,12 +120,20 @@ class SpecificFundamentalTest extends TestCase
      *
      * @return void
      */
-    public function specificFundamentalInfo()
+    public function specificFundamentalInfo(
+        $typeMessageError,
+        $expectedMessage,
+        $expected,
+        bool $permission
+    )
     {
         $specificFundamental = SpecificFundamental::factory()->make();
         $specificFundamental->save();
 
-        $this->graphQL(
+        $this->checkPermission($permission, $this->permission, 'edit-specific-fundamental');
+        $this->checkPermission($permission, $this->permission, 'view-specific-fundamental');
+
+        $response = $this->graphQL(
             'specificFundamental',
             [
                 'id' => $specificFundamental->id,
@@ -87,11 +141,46 @@ class SpecificFundamentalTest extends TestCase
             $this->data,
             'query',
             false
-        )->assertJsonStructure([
-            'data' => [
-                'specificFundamental' => $this->data,
+        );
+
+        $this->assertMessageError(
+            $typeMessageError,
+            $response,
+            $permission,
+            $expectedMessage
+        );
+
+        if ($permission) {
+            $response->assertJsonStructure($expected)
+                ->assertStatus(200);
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function infoProvider()
+    {
+        return [
+            'with permission' => [
+                'type_message_error' => false,
+                'expected_message' => false,
+                'expected' => [
+                    'data' => [
+                        'specificFundamental' => $this->data,
+                    ],
+                ],
+                'permission' => true,
             ],
-        ])->assertStatus(200);
+            'without permission' => [
+                'type_message_error' => 'message',
+                'expected_message' => $this->unauthorized,
+                'expected' => [
+                    'errors' => $this->errors,
+                ],
+                'permission' => false,
+            ],
+        ];
     }
 
     /**

--- a/tests/Feature/GraphQL/SpecificFundamentalTest.php
+++ b/tests/Feature/GraphQL/SpecificFundamentalTest.php
@@ -69,7 +69,7 @@ class SpecificFundamentalTest extends TestCase
      * @test
      *
      * @author Maicon Cerutti
-     * 
+     *
      * @dataProvider infoProvider
      *
      * @return void

--- a/tests/Feature/GraphQL/SpecificFundamentalTest.php
+++ b/tests/Feature/GraphQL/SpecificFundamentalTest.php
@@ -15,7 +15,7 @@ class SpecificFundamentalTest extends TestCase
 
     protected $login = true;
 
-    private $permission = 'technician';
+    private $role = 'technician';
 
     private $data = [
         'id',
@@ -24,6 +24,12 @@ class SpecificFundamentalTest extends TestCase
         'createdAt',
         'updatedAt',
     ];
+
+    private function setPermissions(bool $hasPermission)
+    {
+        $this->checkPermission($hasPermission, $this->role, 'edit-specific-fundamental');
+        $this->checkPermission($hasPermission, $this->role, 'view-specific-fundamental');
+    }
 
     /**
      * Listagem de todos os fundamentos especificos.
@@ -40,12 +46,11 @@ class SpecificFundamentalTest extends TestCase
         $typeMessageError,
         $expectedMessage,
         $expected,
-        bool $permission
+        bool $hasPermission
     ) {
-        SpecificFundamental::factory()->make()->save();
+        $this->setPermissions($hasPermission);
 
-        $this->checkPermission($permission, $this->permission, 'edit-specific-fundamental');
-        $this->checkPermission($permission, $this->permission, 'view-specific-fundamental');
+        SpecificFundamental::factory()->make()->save();
 
         $response = $this->graphQL(
             'specificFundamentals',
@@ -65,11 +70,11 @@ class SpecificFundamentalTest extends TestCase
         $this->assertMessageError(
             $typeMessageError,
             $response,
-            $permission,
+            $hasPermission,
             $expectedMessage
         );
 
-        if ($permission) {
+        if ($hasPermission) {
             $response
                 ->assertJsonStructure($expected)
                 ->assertStatus(200);
@@ -123,13 +128,12 @@ class SpecificFundamentalTest extends TestCase
         $typeMessageError,
         $expectedMessage,
         $expected,
-        bool $permission
+        bool $hasPermission
     ) {
+        $this->setPermissions($hasPermission);
+
         $specificFundamental = SpecificFundamental::factory()->make();
         $specificFundamental->save();
-
-        $this->checkPermission($permission, $this->permission, 'edit-specific-fundamental');
-        $this->checkPermission($permission, $this->permission, 'view-specific-fundamental');
 
         $response = $this->graphQL(
             'specificFundamental',
@@ -144,11 +148,11 @@ class SpecificFundamentalTest extends TestCase
         $this->assertMessageError(
             $typeMessageError,
             $response,
-            $permission,
+            $hasPermission,
             $expectedMessage
         );
 
-        if ($permission) {
+        if ($hasPermission) {
             $response->assertJsonStructure($expected)
                 ->assertStatus(200);
         }
@@ -197,10 +201,10 @@ class SpecificFundamentalTest extends TestCase
         $typeMessageError,
         $expectedMessage,
         $expected,
-        $permission,
+        $hasPermission,
         $addRelationship
         ) {
-        $this->checkPermission($permission, $this->permission, 'edit-specific-fundamental');
+        $this->setPermissions($hasPermission);
 
         $fundamental = Fundamental::factory()->make();
         $fundamental->save();
@@ -218,7 +222,7 @@ class SpecificFundamentalTest extends TestCase
             true
         );
 
-        $this->assertMessageError($typeMessageError, $response, $permission, $expectedMessage);
+        $this->assertMessageError($typeMessageError, $response, $hasPermission, $expectedMessage);
 
         $response
             ->assertJsonStructure($expected)
@@ -341,10 +345,10 @@ class SpecificFundamentalTest extends TestCase
         $typeMessageError,
         $expectedMessage,
         $expected,
-        $permission,
+        $hasPermission,
         $addRelationship
         ) {
-        $this->checkPermission($permission, $this->permission, 'edit-specific-fundamental');
+        $this->setPermissions($hasPermission);
 
         $specificFundamentalExist = SpecificFundamental::factory()->make();
         $specificFundamentalExist->save();
@@ -373,7 +377,7 @@ class SpecificFundamentalTest extends TestCase
             true
         );
 
-        $this->assertMessageError($typeMessageError, $response, $permission, $expectedMessage);
+        $this->assertMessageError($typeMessageError, $response, $hasPermission, $expectedMessage);
 
         $response
             ->assertJsonStructure($expected)
@@ -489,11 +493,9 @@ class SpecificFundamentalTest extends TestCase
      *
      * @return void
      */
-    public function specificFundamentalDelete($data, $typeMessageError, $expectedMessage, $expected, $permission)
+    public function specificFundamentalDelete($data, $typeMessageError, $expectedMessage, $expected, $hasPermission)
     {
-        $this->login = true;
-
-        $this->checkPermission($permission, $this->permission, 'edit-specific-fundamental');
+        $this->setPermissions($hasPermission);
 
         $specificFundamental = SpecificFundamental::factory()->make();
         $specificFundamental->save();
@@ -513,7 +515,7 @@ class SpecificFundamentalTest extends TestCase
             true
         );
 
-        $this->assertMessageError($typeMessageError, $response, $permission, $expectedMessage);
+        $this->assertMessageError($typeMessageError, $response, $hasPermission, $expectedMessage);
 
         $response
             ->assertJsonStructure($expected)

--- a/tests/Feature/GraphQL/SpecificFundamentalTest.php
+++ b/tests/Feature/GraphQL/SpecificFundamentalTest.php
@@ -69,6 +69,8 @@ class SpecificFundamentalTest extends TestCase
      * @test
      *
      * @author Maicon Cerutti
+     * 
+     * @dataProvider infoProvider
      *
      * @return void
      */

--- a/tests/Feature/GraphQL/TeamTest.php
+++ b/tests/Feature/GraphQL/TeamTest.php
@@ -32,7 +32,7 @@ class TeamTest extends TestCase
      * @author Maicon Cerutti
      *
      * @test
-     * 
+     *
      * @dataProvider listProvider
      *
      * @return void
@@ -42,8 +42,7 @@ class TeamTest extends TestCase
         $expectedMessage,
         $expected,
         bool $permission
-    )
-    {
+    ) {
         Team::factory()->make()->save();
 
         $this->checkPermission($permission, $this->permission, 'edit-team');
@@ -168,7 +167,7 @@ class TeamTest extends TestCase
                 'expected' => [
                     'data' => [
                         'team' => $this->data,
-                    ]
+                    ],
                 ],
                 'permission' => true,
             ],

--- a/tests/Feature/GraphQL/TeamTest.php
+++ b/tests/Feature/GraphQL/TeamTest.php
@@ -70,7 +70,7 @@ class TeamTest extends TestCase
      * @author Maicon Cerutti
      *
      * @test
-     * 
+     *
      * @dataProvider infoProvider
      *
      * @return void
@@ -80,8 +80,7 @@ class TeamTest extends TestCase
         $expectedMessage,
         $expected,
         bool $permission
-    )
-    {
+    ) {
         $team = Team::factory()->make();
         $team->save();
 
@@ -104,8 +103,8 @@ class TeamTest extends TestCase
             $permission,
             $expectedMessage
         );
-        
-        if($permission) {
+
+        if ($permission) {
             $response->assertJsonStructure([
                 'data' => [
                     'team' => $this->data,

--- a/tests/Feature/GraphQL/TeamTest.php
+++ b/tests/Feature/GraphQL/TeamTest.php
@@ -16,7 +16,7 @@ class TeamTest extends TestCase
 
     private $teamText = ' TEAM';
 
-    private $permission = 'technician';
+    private $role = 'technician';
 
     private $data = [
         'id',
@@ -25,6 +25,12 @@ class TeamTest extends TestCase
         'createdAt',
         'updatedAt',
     ];
+
+    private function setPermissions(bool $hasPermission)
+    {
+        $this->checkPermission($hasPermission, $this->role, 'edit-team');
+        $this->checkPermission($hasPermission, $this->role, 'view-team');
+    }
 
     /**
      * Listagem de todos os times.
@@ -41,12 +47,11 @@ class TeamTest extends TestCase
         $typeMessageError,
         $expectedMessage,
         $expected,
-        bool $permission
+        bool $hasPermission
     ) {
-        Team::factory()->make()->save();
+        $this->setPermissions($hasPermission);
 
-        $this->checkPermission($permission, $this->permission, 'edit-team');
-        $this->checkPermission($permission, $this->permission, 'view-team');
+        Team::factory()->make()->save();
 
         $response = $this->graphQL(
             'teams',
@@ -66,11 +71,11 @@ class TeamTest extends TestCase
         $this->assertMessageError(
             $typeMessageError,
             $response,
-            $permission,
+            $hasPermission,
             $expectedMessage
         );
 
-        if ($permission) {
+        if ($hasPermission) {
             $response
                 ->assertJsonStructure($expected)
                 ->assertStatus(200);
@@ -124,13 +129,12 @@ class TeamTest extends TestCase
         $typeMessageError,
         $expectedMessage,
         $expected,
-        bool $permission
+        bool $hasPermission
     ) {
+        $this->setPermissions($hasPermission);
+
         $team = Team::factory()->make();
         $team->save();
-
-        $this->checkPermission($permission, $this->permission, 'edit-team');
-        $this->checkPermission($permission, $this->permission, 'view-team');
 
         $response = $this->graphQL(
             'team',
@@ -145,11 +149,11 @@ class TeamTest extends TestCase
         $this->assertMessageError(
             $typeMessageError,
             $response,
-            $permission,
+            $hasPermission,
             $expectedMessage
         );
 
-        if ($permission) {
+        if ($hasPermission) {
             $response->assertJsonStructure($expected)
                 ->assertStatus(200);
         }
@@ -198,9 +202,9 @@ class TeamTest extends TestCase
         $typeMessageError,
         $expectedMessage,
         $expected,
-        $permission
+        $hasPermission
         ) {
-        $this->checkPermission($permission, $this->permission, 'edit-team');
+        $this->setPermissions($hasPermission);
 
         $response = $this->graphQL(
             'teamCreate',
@@ -211,7 +215,7 @@ class TeamTest extends TestCase
             true
         );
 
-        $this->assertMessageError($typeMessageError, $response, $permission, $expectedMessage);
+        $this->assertMessageError($typeMessageError, $response, $hasPermission, $expectedMessage);
 
         $response
             ->assertJsonStructure($expected)
@@ -334,9 +338,9 @@ class TeamTest extends TestCase
         $typeMessageError,
         $expectedMessage,
         $expected,
-        $permission
+        $hasPermission
         ) {
-        $this->checkPermission($permission, $this->permission, 'edit-team');
+        $this->setPermissions($hasPermission);
 
         $teamExist = Team::factory()->make();
         $teamExist->save();
@@ -358,7 +362,7 @@ class TeamTest extends TestCase
             true
         );
 
-        $this->assertMessageError($typeMessageError, $response, $permission, $expectedMessage);
+        $this->assertMessageError($typeMessageError, $response, $hasPermission, $expectedMessage);
 
         $response
             ->assertJsonStructure($expected)
@@ -469,11 +473,9 @@ class TeamTest extends TestCase
      *
      * @return void
      */
-    public function teamDelete($data, $typeMessageError, $expectedMessage, $expected, $permission)
+    public function teamDelete($data, $typeMessageError, $expectedMessage, $expected, $hasPermission)
     {
-        $this->login = true;
-
-        $this->checkPermission($permission, $this->permission, 'edit-team');
+        $this->setPermissions($hasPermission);
 
         $team = Team::factory()->make();
         $team->save();
@@ -493,7 +495,7 @@ class TeamTest extends TestCase
             true
         );
 
-        $this->assertMessageError($typeMessageError, $response, $permission, $expectedMessage);
+        $this->assertMessageError($typeMessageError, $response, $hasPermission, $expectedMessage);
 
         $response
             ->assertJsonStructure($expected)

--- a/tests/Feature/GraphQL/TeamTest.php
+++ b/tests/Feature/GraphQL/TeamTest.php
@@ -32,14 +32,24 @@ class TeamTest extends TestCase
      * @author Maicon Cerutti
      *
      * @test
+     * 
+     * @dataProvider listProvider
      *
      * @return void
      */
-    public function teamsList()
+    public function teamsList(
+        $typeMessageError,
+        $expectedMessage,
+        $expected,
+        bool $permission
+    )
     {
         Team::factory()->make()->save();
 
-        $this->graphQL(
+        $this->checkPermission($permission, $this->permission, 'edit-team');
+        $this->checkPermission($permission, $this->permission, 'view-team');
+
+        $response = $this->graphQL(
             'teams',
             [
                 'name' => '%%',
@@ -52,16 +62,52 @@ class TeamTest extends TestCase
             ],
             'query',
             false
-        )->assertJsonStructure([
-            'data' => [
-                'teams' => [
-                    'paginatorInfo' => $this->paginatorInfo,
+        );
+
+        $this->assertMessageError(
+            $typeMessageError,
+            $response,
+            $permission,
+            $expectedMessage
+        );
+
+        if ($permission) {
+            $response
+                ->assertJsonStructure($expected)
+                ->assertStatus(200);
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function listProvider()
+    {
+        return [
+            'with permission' => [
+                'type_message_error' => false,
+                'expected_message' => false,
+                'expected' => [
                     'data' => [
-                        '*' => $this->data,
+                        'teams' => [
+                            'paginatorInfo' => $this->paginatorInfo,
+                            'data' => [
+                                '*' => $this->data,
+                            ],
+                        ],
                     ],
                 ],
+                'permission' => true,
             ],
-        ])->assertStatus(200);
+            'without permission' => [
+                'type_message_error' => 'message',
+                'expected_message' => $this->unauthorized,
+                'expected' => [
+                    'errors' => $this->errors,
+                ],
+                'permission' => false,
+            ],
+        ];
     }
 
     /**
@@ -105,11 +151,8 @@ class TeamTest extends TestCase
         );
 
         if ($permission) {
-            $response->assertJsonStructure([
-                'data' => [
-                    'team' => $this->data,
-                ],
-            ])->assertStatus(200);
+            $response->assertJsonStructure($expected)
+                ->assertStatus(200);
         }
     }
 
@@ -124,8 +167,8 @@ class TeamTest extends TestCase
                 'expected_message' => false,
                 'expected' => [
                     'data' => [
-                        'config' => $this->data,
-                    ],
+                        'team' => $this->data,
+                    ]
                 ],
                 'permission' => true,
             ],

--- a/tests/Feature/GraphQL/TeamTest.php
+++ b/tests/Feature/GraphQL/TeamTest.php
@@ -101,7 +101,7 @@ class TeamTest extends TestCase
                         ],
                     ],
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'without permission' => [
                 'type_message_error' => 'message',
@@ -109,7 +109,7 @@ class TeamTest extends TestCase
                 'expected' => [
                     'errors' => $this->errors,
                 ],
-                'permission' => false,
+                'hasPermission' => false,
             ],
         ];
     }
@@ -173,7 +173,7 @@ class TeamTest extends TestCase
                         'team' => $this->data,
                     ],
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'without permission' => [
                 'type_message_error' => 'message',
@@ -181,7 +181,7 @@ class TeamTest extends TestCase
                 'expected' => [
                     'errors' => $this->errors,
                 ],
-                'permission' => false,
+                'hasPermission' => false,
             ],
         ];
     }
@@ -245,7 +245,7 @@ class TeamTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $teamCreate,
                 ],
-                'permission' => false,
+                'hasPermission' => false,
             ],
             'create team, success' => [
                 [
@@ -260,7 +260,7 @@ class TeamTest extends TestCase
                         'teamCreate' => $this->data,
                     ],
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'create team and relating a players, success' => [
                 [
@@ -275,7 +275,7 @@ class TeamTest extends TestCase
                         'teamCreate' => $this->data,
                     ],
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'name field is not unique, expected error' => [
                 [
@@ -289,7 +289,7 @@ class TeamTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $teamCreate,
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'name field is required, expected error' => [
                 [
@@ -303,7 +303,7 @@ class TeamTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $teamCreate,
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'name field is min 3 characteres, expected error' => [
                 [
@@ -317,7 +317,7 @@ class TeamTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $teamCreate,
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
         ];
     }
@@ -390,7 +390,7 @@ class TeamTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $teamEdit,
                 ],
-                'permission' => false,
+                'hasPermission' => false,
             ],
             'edit team, success' => [
                 [
@@ -404,7 +404,7 @@ class TeamTest extends TestCase
                         'teamEdit' => $this->data,
                     ],
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'edit team and relating a players, success' => [
                 [
@@ -419,7 +419,7 @@ class TeamTest extends TestCase
                         'teamEdit' => $this->data,
                     ],
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'name field is not unique, expected error' => [
                 [
@@ -431,7 +431,7 @@ class TeamTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $teamEdit,
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'name field is required, expected error' => [
                 [
@@ -444,7 +444,7 @@ class TeamTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $teamEdit,
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'name field is min 3 characteres, expected error' => [
                 [
@@ -457,7 +457,7 @@ class TeamTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $teamEdit,
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
         ];
     }
@@ -523,7 +523,7 @@ class TeamTest extends TestCase
                         'teamDelete' => [$this->data],
                     ],
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'delete team without permission, expected error' => [
                 [
@@ -535,7 +535,7 @@ class TeamTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $teamDelete,
                 ],
-                'permission' => false,
+                'hasPermission' => false,
             ],
             'delete team that does not exist, expected error' => [
                 [
@@ -547,7 +547,7 @@ class TeamTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $teamDelete,
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
         ];
     }

--- a/tests/Feature/GraphQL/TeamTest.php
+++ b/tests/Feature/GraphQL/TeamTest.php
@@ -16,7 +16,7 @@ class TeamTest extends TestCase
 
     private $teamText = ' TEAM';
 
-    private $permission = 'Técnico';
+    private $permission = 'technician';
 
     private $data = [
         'id',
@@ -111,7 +111,7 @@ class TeamTest extends TestCase
         $expected,
         $permission
         ) {
-        $this->checkPermission($permission, $this->permission, 'create-team');
+        $this->checkPermission($permission, $this->permission, 'edit-team');
 
         $response = $this->graphQL(
             'teamCreate',
@@ -384,7 +384,7 @@ class TeamTest extends TestCase
     {
         $this->login = true;
 
-        $this->checkPermission($permission, $this->permission, 'delete-team');
+        $this->checkPermission($permission, $this->permission, 'edit-team');
 
         $team = Team::factory()->make();
         $team->save();

--- a/tests/Feature/GraphQL/TrainingConfigTest.php
+++ b/tests/Feature/GraphQL/TrainingConfigTest.php
@@ -63,11 +63,8 @@ class TrainingConfigTest extends TestCase
         );
 
         if ($permission) {
-            $response->assertJsonStructure([
-                'data' => [
-                    'trainingConfig' => $this->data,
-                ],
-            ])->assertStatus(200);
+            $response->assertJsonStructure($expected)
+                ->assertStatus(200);
         }
     }
 
@@ -82,8 +79,8 @@ class TrainingConfigTest extends TestCase
                 'expected_message' => false,
                 'expected' => [
                     'data' => [
-                        'config' => $this->data,
-                    ],
+                        'trainingConfig' => $this->data,
+                    ]
                 ],
                 'permission' => true,
             ],

--- a/tests/Feature/GraphQL/TrainingConfigTest.php
+++ b/tests/Feature/GraphQL/TrainingConfigTest.php
@@ -13,7 +13,7 @@ class TrainingConfigTest extends TestCase
 
     protected $login = true;
 
-    private $permission = 'Técnico';
+    private $permission = 'technician';
 
     private $data = [
         'id',

--- a/tests/Feature/GraphQL/TrainingConfigTest.php
+++ b/tests/Feature/GraphQL/TrainingConfigTest.php
@@ -13,7 +13,7 @@ class TrainingConfigTest extends TestCase
 
     protected $login = true;
 
-    private $permission = 'technician';
+    private $role = 'technician';
 
     private $data = [
         'id',
@@ -24,6 +24,12 @@ class TrainingConfigTest extends TestCase
         'createdAt',
         'updatedAt',
     ];
+
+    private function setPermissions(bool $hasPermission)
+    {
+        $this->checkPermission($hasPermission, $this->role, 'edit-training-config');
+        $this->checkPermission($hasPermission, $this->role, 'view-training-config');
+    }
 
     /**
      * Listagem de configurações de treino.
@@ -40,10 +46,9 @@ class TrainingConfigTest extends TestCase
         $typeMessageError,
         $expectedMessage,
         $expected,
-        bool $permission
+        bool $hasPermission
     ) {
-        $this->checkPermission($permission, $this->permission, 'edit-training-config');
-        $this->checkPermission($permission, $this->permission, 'view-training-config');
+        $this->setPermissions($hasPermission);
 
         $response = $this->graphQL(
             'trainingConfig',
@@ -58,11 +63,11 @@ class TrainingConfigTest extends TestCase
         $this->assertMessageError(
             $typeMessageError,
             $response,
-            $permission,
+            $hasPermission,
             $expectedMessage
         );
 
-        if ($permission) {
+        if ($hasPermission) {
             $response->assertJsonStructure($expected)
                 ->assertStatus(200);
         }
@@ -111,9 +116,9 @@ class TrainingConfigTest extends TestCase
         $typeMessageError,
         $expectedMessage,
         $expected,
-        $permission
+        bool $hasPermission
     ) {
-        $this->checkPermission($permission, $this->permission, 'edit-training-config');
+        $this->setPermissions($hasPermission);
 
         $parameters['id'] = 1;
 
@@ -129,7 +134,7 @@ class TrainingConfigTest extends TestCase
         $this->assertMessageError(
             $typeMessageError,
             $response,
-            $permission,
+            $hasPermission,
             $expectedMessage
         );
 

--- a/tests/Feature/GraphQL/TrainingConfigTest.php
+++ b/tests/Feature/GraphQL/TrainingConfigTest.php
@@ -80,7 +80,7 @@ class TrainingConfigTest extends TestCase
                 'expected' => [
                     'data' => [
                         'trainingConfig' => $this->data,
-                    ]
+                    ],
                 ],
                 'permission' => true,
             ],

--- a/tests/Feature/GraphQL/TrainingConfigTest.php
+++ b/tests/Feature/GraphQL/TrainingConfigTest.php
@@ -41,8 +41,7 @@ class TrainingConfigTest extends TestCase
         $expectedMessage,
         $expected,
         bool $permission
-    )
-    {
+    ) {
         $this->checkPermission($permission, $this->permission, 'edit-training-config');
         $this->checkPermission($permission, $this->permission, 'view-training-config');
 
@@ -62,8 +61,8 @@ class TrainingConfigTest extends TestCase
             $permission,
             $expectedMessage
         );
-        
-        if($permission) {
+
+        if ($permission) {
             $response->assertJsonStructure([
                 'data' => [
                     'trainingConfig' => $this->data,

--- a/tests/Feature/GraphQL/TrainingConfigTest.php
+++ b/tests/Feature/GraphQL/TrainingConfigTest.php
@@ -87,7 +87,7 @@ class TrainingConfigTest extends TestCase
                         'trainingConfig' => $this->data,
                     ],
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'without permission' => [
                 'type_message_error' => 'message',
@@ -95,7 +95,7 @@ class TrainingConfigTest extends TestCase
                 'expected' => [
                     'errors' => $this->errors,
                 ],
-                'permission' => false,
+                'hasPermission' => false,
             ],
         ];
     }
@@ -166,7 +166,7 @@ class TrainingConfigTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $trainingConfigEdit,
                 ],
-                'permission' => false,
+                'hasPermission' => false,
             ],
             'edit config, success' => [
                 [
@@ -182,7 +182,7 @@ class TrainingConfigTest extends TestCase
                         'trainingConfigEdit' => $this->data,
                     ],
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
         ];
     }

--- a/tests/Feature/GraphQL/TrainingTest.php
+++ b/tests/Feature/GraphQL/TrainingTest.php
@@ -18,7 +18,7 @@ class TrainingTest extends TestCase
 
     private $trainingText = ' TRAINING';
 
-    private $permission = 'technician';
+    private $role = 'technician';
 
     private $dateStart = '2022-10-23 13:50:00';
 
@@ -47,6 +47,12 @@ class TrainingTest extends TestCase
         'updatedAt',
     ];
 
+    private function setPermissions(bool $hasPermission) : void
+    {
+        $this->checkPermission($hasPermission, $this->role, 'edit-training');
+        $this->checkPermission($hasPermission, $this->role, 'view-training');
+    }
+
     /**
      * Listagem de todos os treinos.
      *
@@ -62,12 +68,11 @@ class TrainingTest extends TestCase
         $typeMessageError,
         $expectedMessage,
         $expected,
-        bool $permission
+        bool $hasPermission
     ) {
-        Training::factory()->make()->save();
+        $this->setPermissions($hasPermission);
 
-        $this->checkPermission($permission, $this->permission, 'edit-training');
-        $this->checkPermission($permission, $this->permission, 'view-training');
+        Training::factory()->make()->save();
 
         $response = $this->graphQL(
             'trainings',
@@ -87,11 +92,11 @@ class TrainingTest extends TestCase
         $this->assertMessageError(
             $typeMessageError,
             $response,
-            $permission,
+            $hasPermission,
             $expectedMessage
         );
 
-        if ($permission) {
+        if ($hasPermission) {
             $response
                 ->assertJsonStructure($expected)
                 ->assertStatus(200);
@@ -145,13 +150,12 @@ class TrainingTest extends TestCase
         $typeMessageError,
         $expectedMessage,
         $expected,
-        bool $permission
+        bool $hasPermission
     ) {
+        $this->setPermissions($hasPermission);
+
         $training = Training::factory()->make();
         $training->save();
-
-        $this->checkPermission($permission, $this->permission, 'edit-training');
-        $this->checkPermission($permission, $this->permission, 'view-training');
 
         $response = $this->graphQL(
             'training',
@@ -166,11 +170,11 @@ class TrainingTest extends TestCase
         $this->assertMessageError(
             $typeMessageError,
             $response,
-            $permission,
+            $hasPermission,
             $expectedMessage
         );
 
-        if ($permission) {
+        if ($hasPermission) {
             $response->assertJsonStructure($expected)
                 ->assertStatus(200);
         }
@@ -220,13 +224,9 @@ class TrainingTest extends TestCase
         $typeMessageError,
         $expectedMessage,
         $expected,
-        $permission
+        bool $hasPermission
     ) {
-        $this->checkPermission(
-            $permission,
-            $this->permission,
-            'edit-training'
-        );
+        $this->setPermissions($hasPermission);
 
         $team = Team::factory()
             ->hasPlayers(10)
@@ -254,7 +254,7 @@ class TrainingTest extends TestCase
         $this->assertMessageError(
             $typeMessageError,
             $response,
-            $permission,
+            $hasPermission,
             $expectedMessage
         );
 
@@ -544,13 +544,9 @@ class TrainingTest extends TestCase
         $typeMessageError,
         $expectedMessage,
         $expected,
-        $permission
+        bool $hasPermission
     ) {
-        $this->checkPermission(
-            $permission,
-            $this->permission,
-            'edit-training'
-        );
+        $this->setPermissions($hasPermission);
 
         $training = Training::factory()->make();
         $training->save();
@@ -582,7 +578,7 @@ class TrainingTest extends TestCase
         $this->assertMessageError(
             $typeMessageError,
             $response,
-            $permission,
+            $hasPermission,
             $expectedMessage
         );
 
@@ -902,11 +898,9 @@ class TrainingTest extends TestCase
         $typeMessageError,
         $expectedMessage,
         $expected,
-        $permission
+        bool $hasPermission
     ) {
-        $this->login = true;
-
-        $this->checkPermission($permission, $this->permission, 'edit-training');
+        $this->setPermissions($hasPermission);
 
         $training = Training::factory()->make();
         $training->save();
@@ -926,7 +920,7 @@ class TrainingTest extends TestCase
             true
         );
 
-        $this->assertMessageError($typeMessageError, $response, $permission, $expectedMessage);
+        $this->assertMessageError($typeMessageError, $response, $hasPermission, $expectedMessage);
 
         $response
             ->assertJsonStructure($expected)

--- a/tests/Feature/GraphQL/TrainingTest.php
+++ b/tests/Feature/GraphQL/TrainingTest.php
@@ -122,7 +122,7 @@ class TrainingTest extends TestCase
                         ],
                     ],
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'without permission' => [
                 'type_message_error' => 'message',
@@ -130,7 +130,7 @@ class TrainingTest extends TestCase
                 'expected' => [
                     'errors' => $this->errors,
                 ],
-                'permission' => false,
+                'hasPermission' => false,
             ],
         ];
     }
@@ -194,7 +194,7 @@ class TrainingTest extends TestCase
                         'training' => $this->data,
                     ],
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'without permission' => [
                 'type_message_error' => 'message',
@@ -202,7 +202,7 @@ class TrainingTest extends TestCase
                 'expected' => [
                     'errors' => $this->errors,
                 ],
-                'permission' => false,
+                'hasPermission' => false,
             ],
         ];
     }
@@ -303,7 +303,7 @@ class TrainingTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $trainingCreate,
                 ],
-                'permission' => false,
+                'hasPermission' => false,
             ],
             'create training with minimal parameters, success' => [
                 [
@@ -320,7 +320,7 @@ class TrainingTest extends TestCase
                         'trainingCreate' => $this->data,
                     ],
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'create training with full parameters, success' => [
                 [
@@ -337,7 +337,7 @@ class TrainingTest extends TestCase
                         'trainingCreate' => $this->data,
                     ],
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'create training with relationship fundamentals, success' => [
                 [
@@ -355,7 +355,7 @@ class TrainingTest extends TestCase
                         'trainingCreate' => $this->data,
                     ],
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'create training with relationship specific fundamental, success' => [
                 [
@@ -374,7 +374,7 @@ class TrainingTest extends TestCase
                         'trainingCreate' => $this->data,
                     ],
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'create training with notification if training date is current day, success' => [
                 [
@@ -393,7 +393,7 @@ class TrainingTest extends TestCase
                         'trainingCreate' => $this->data,
                     ],
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
         ];
     }
@@ -430,7 +430,7 @@ class TrainingTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $trainingCreate,
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'name field is min 3 characteres, expected error' => [
                 [
@@ -445,7 +445,7 @@ class TrainingTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $trainingCreate,
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'DateStart must be less than dateEnd, expected error' => [
                 [
@@ -460,7 +460,7 @@ class TrainingTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $trainingCreate,
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'DateEnd must be greater than dateStart, expected error' => [
                 [
@@ -475,7 +475,7 @@ class TrainingTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $trainingCreate,
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'DateEnd without correct formatting, expected error' => [
                 [
@@ -490,7 +490,7 @@ class TrainingTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $trainingCreate,
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'DateStart without correct formatting, expected error' => [
                 [
@@ -505,7 +505,7 @@ class TrainingTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $trainingCreate,
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'specific fundamentals unrelated to fundamentals on record, expected error' => [
                 [
@@ -522,7 +522,7 @@ class TrainingTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $trainingCreate,
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
         ];
     }
@@ -627,7 +627,7 @@ class TrainingTest extends TestCase
                         'trainingEdit' => $this->data,
                     ],
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'edit training with full parameters, success' => [
                 [
@@ -644,7 +644,7 @@ class TrainingTest extends TestCase
                         'trainingEdit' => $this->data,
                     ],
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'edit training with relationship fundamentals, success' => [
                 [
@@ -662,7 +662,7 @@ class TrainingTest extends TestCase
                         'trainingEdit' => $this->data,
                     ],
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'edit training with relationship specific fundamental, success' => [
                 [
@@ -681,7 +681,7 @@ class TrainingTest extends TestCase
                         'trainingEdit' => $this->data,
                     ],
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'edit training cancel, success' => [
                 [
@@ -699,7 +699,7 @@ class TrainingTest extends TestCase
                         'trainingEdit' => $this->data,
                     ],
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'edit training reactivate, success' => [
                 [
@@ -717,7 +717,7 @@ class TrainingTest extends TestCase
                         'trainingEdit' => $this->data,
                     ],
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'edit training with notification if training date is current day, success' => [
                 [
@@ -735,7 +735,7 @@ class TrainingTest extends TestCase
                         'trainingEdit' => $this->data,
                     ],
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
         ];
     }
@@ -772,7 +772,7 @@ class TrainingTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $trainingEdit,
                 ],
-                'permission' => false,
+                'hasPermission' => false,
             ],
             'name field is required, expected error' => [
                 [
@@ -787,7 +787,7 @@ class TrainingTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $trainingEdit,
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'name field is min 3 characteres, expected error' => [
                 [
@@ -802,7 +802,7 @@ class TrainingTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $trainingEdit,
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'DateStart must be less than dateEnd, expected error' => [
                 [
@@ -817,7 +817,7 @@ class TrainingTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $trainingEdit,
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'DateEnd must be greater than dateStart, expected error' => [
                 [
@@ -832,7 +832,7 @@ class TrainingTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $trainingEdit,
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'DateEnd without correct formatting, expected error' => [
                 [
@@ -847,7 +847,7 @@ class TrainingTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $trainingEdit,
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'DateStart without correct formatting, expected error' => [
                 [
@@ -862,7 +862,7 @@ class TrainingTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $trainingEdit,
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'specific fundamentals unrelated to fundamentals on record, expected error' => [
                 [
@@ -879,7 +879,7 @@ class TrainingTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $trainingEdit,
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
         ];
     }
@@ -948,7 +948,7 @@ class TrainingTest extends TestCase
                         'trainingDelete' => [$this->data],
                     ],
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'delete training without permission, expected error' => [
                 [
@@ -960,7 +960,7 @@ class TrainingTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $trainingDelete,
                 ],
-                'permission' => false,
+                'hasPermission' => false,
             ],
             'delete training that does not exist, expected error' => [
                 [
@@ -972,7 +972,7 @@ class TrainingTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $trainingDelete,
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
         ];
     }

--- a/tests/Feature/GraphQL/TrainingTest.php
+++ b/tests/Feature/GraphQL/TrainingTest.php
@@ -53,7 +53,7 @@ class TrainingTest extends TestCase
      * @author Maicon Cerutti
      *
      * @test
-     * 
+     *
      * @dataProvider listProvider
      *
      * @return void
@@ -63,8 +63,7 @@ class TrainingTest extends TestCase
         $expectedMessage,
         $expected,
         bool $permission
-    )
-    {
+    ) {
         Training::factory()->make()->save();
 
         $this->checkPermission($permission, $this->permission, 'edit-training');

--- a/tests/Feature/GraphQL/TrainingTest.php
+++ b/tests/Feature/GraphQL/TrainingTest.php
@@ -18,7 +18,7 @@ class TrainingTest extends TestCase
 
     private $trainingText = ' TRAINING';
 
-    private $permission = 'Técnico';
+    private $permission = 'technician';
 
     private $dateStart = '2022-10-23 13:50:00';
 
@@ -136,7 +136,7 @@ class TrainingTest extends TestCase
         $this->checkPermission(
             $permission,
             $this->permission,
-            'create-training'
+            'edit-training'
         );
 
         $team = Team::factory()
@@ -817,7 +817,7 @@ class TrainingTest extends TestCase
     ) {
         $this->login = true;
 
-        $this->checkPermission($permission, $this->permission, 'delete-training');
+        $this->checkPermission($permission, $this->permission, 'edit-training');
 
         $training = Training::factory()->make();
         $training->save();

--- a/tests/Feature/GraphQL/TrainingTest.php
+++ b/tests/Feature/GraphQL/TrainingTest.php
@@ -101,8 +101,7 @@ class TrainingTest extends TestCase
         $expectedMessage,
         $expected,
         bool $permission
-    )
-    {
+    ) {
         $training = Training::factory()->make();
         $training->save();
 
@@ -125,8 +124,8 @@ class TrainingTest extends TestCase
             $permission,
             $expectedMessage
         );
-        
-        if($permission) {
+
+        if ($permission) {
             $response->assertJsonStructure([
                 'data' => [
                     'training' => $this->data,

--- a/tests/Feature/GraphQL/TrainingTest.php
+++ b/tests/Feature/GraphQL/TrainingTest.php
@@ -47,7 +47,7 @@ class TrainingTest extends TestCase
         'updatedAt',
     ];
 
-    private function setPermissions(bool $hasPermission) : void
+    private function setPermissions(bool $hasPermission): void
     {
         $this->checkPermission($hasPermission, $this->role, 'edit-training');
         $this->checkPermission($hasPermission, $this->role, 'view-training');

--- a/tests/Feature/GraphQL/UserTest.php
+++ b/tests/Feature/GraphQL/UserTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\GraphQL;
 
 use App\Models\Position;
 use App\Models\User;
+use App\Models\Team;
 use Faker\Factory as Faker;
 use Tests\TestCase;
 
@@ -207,11 +208,17 @@ class UserTest extends TestCase
         $typeMessageError,
         $expectedMessage,
         $expected,
-        $permission
+        bool $hasTeam,
+        bool $permission
         ) {
         $this->login = true;
 
         $faker = Faker::create();
+
+        if($hasTeam) {
+            $team = Team::factory()->create();
+            $parameters['teamId'] = $team->id;
+        }
 
         $this->checkPermission($permission, $this->permission, 'edit-user');
 
@@ -228,6 +235,8 @@ class UserTest extends TestCase
 
         $this->assertMessageError($typeMessageError, $response, $permission, $expectedMessage);
 
+        /* dump($expected);
+        dd($response->json()); */
         $response
             ->assertJsonStructure($expected)
             ->assertStatus(200);
@@ -252,7 +261,6 @@ class UserTest extends TestCase
                     'email' => $faker->email,
                     'roleId' => [2],
                     'positionId' => [1],
-                    'teamId' => [1, 2],
                     'password' => $password,
                 ],
                 'type_message_error' => false,
@@ -262,6 +270,7 @@ class UserTest extends TestCase
                         'userCreate' => $this->data,
                     ],
                 ],
+                'hasTeam' => true,
                 'permission' => true,
             ],
             'create user with position, success' => [
@@ -279,6 +288,7 @@ class UserTest extends TestCase
                         'userCreate' => $this->data,
                     ],
                 ],
+                'hasTeam' => false,
                 'permission' => true,
             ],
             'declare roleId is required, expected error' => [
@@ -294,6 +304,7 @@ class UserTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $userCreate,
                 ],
+                'hasTeam' => false,
                 'permission' => true,
             ],
             'create user, success' => [
@@ -310,13 +321,14 @@ class UserTest extends TestCase
                         'userCreate' => $this->data,
                     ],
                 ],
+                'hasTeam' => false,
                 'permission' => true,
             ],
             'create user with 2 roles, success' => [
                 [
                     'name' => $faker->name,
                     'email' => $faker->email,
-                    'roleId' => [2, 3],
+                    'roleId' => [3],
                     'password' => $password,
                 ],
                 'type_message_error' => false,
@@ -326,6 +338,7 @@ class UserTest extends TestCase
                         'userCreate' => $this->data,
                     ],
                 ],
+                'hasTeam' => false,
                 'permission' => true,
             ],
             'create user with permission that shouldnt have, expected error' => [
@@ -341,6 +354,7 @@ class UserTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $userCreate,
                 ],
+                'hasTeam' => false,
                 'permission' => true,
             ],
             'create user without permission, expected error' => [
@@ -356,6 +370,7 @@ class UserTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $userCreate,
                 ],
+                'hasTeam' => false,
                 'permission' => false,
             ],
             'text password less than 6 characters, expected error' => [
@@ -371,6 +386,7 @@ class UserTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $userCreate,
                 ],
+                'hasTeam' => false,
                 'permission' => true,
             ],
             'no text password, expected error' => [
@@ -385,6 +401,7 @@ class UserTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $userCreate,
                 ],
+                'hasTeam' => false,
                 'permission' => true,
             ],
             'text password with 6 characters, success' => [
@@ -401,6 +418,7 @@ class UserTest extends TestCase
                         'userCreate' => $this->data,
                     ],
                 ],
+                'hasTeam' => false,
                 'permission' => true,
             ],
             'email field is required, expected error' => [
@@ -416,6 +434,7 @@ class UserTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $userCreate,
                 ],
+                'hasTeam' => false,
                 'permission' => true,
             ],
             'email field is not unique, expected error' => [
@@ -431,6 +450,7 @@ class UserTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $userCreate,
                 ],
+                'hasTeam' => false,
                 'permission' => true,
             ],
             'email field is not email valid, expected error' => [
@@ -446,6 +466,7 @@ class UserTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $userCreate,
                 ],
+                'hasTeam' => false,
                 'permission' => true,
             ],
         ];
@@ -462,7 +483,14 @@ class UserTest extends TestCase
      *
      * @return void
      */
-    public function userEdit($parameters, $typeMessageError, $expectedMessage, $expected, $permission)
+    public function userEdit(
+        $parameters, 
+        $typeMessageError, 
+        $expectedMessage, 
+        $expected, 
+        bool $hasTeam,
+        bool $permission
+        )
     {
         $this->login = true;
 
@@ -475,6 +503,11 @@ class UserTest extends TestCase
         $user = User::factory()
             ->has(Position::factory()->count(3))
             ->create();
+
+        if($hasTeam) {
+            $team = Team::factory()->create();
+            $parameters['teamId'] = $team->id;
+        }
 
         $parameters['id'] = $user->id;
 
@@ -522,6 +555,7 @@ class UserTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $userEdit,
                 ],
+                'hasTeam' => false,
                 'permission' => true,
             ],
             'edit user with permission that shouldnt have, expected error' => [
@@ -537,6 +571,7 @@ class UserTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $userEdit,
                 ],
+                'hasTeam' => false,
                 'permission' => true,
             ],
             'edit user without permission, expected error' => [
@@ -552,6 +587,7 @@ class UserTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $userEdit,
                 ],
+                'hasTeam' => false,
                 'permission' => false,
             ],
             'edit user with team, success' => [
@@ -561,7 +597,6 @@ class UserTest extends TestCase
                     'password' => $password,
                     'roleId' => [2],
                     'positionId' => [2],
-                    'teamId' => [1, 2],
                 ],
                 'type_message_error' => false,
                 'expected_message' => false,
@@ -570,6 +605,7 @@ class UserTest extends TestCase
                         'userEdit' => $this->data,
                     ],
                 ],
+                'hasTeam' => true,
                 'permission' => true,
             ],
             'edit user with position, success' => [
@@ -587,6 +623,7 @@ class UserTest extends TestCase
                         'userEdit' => $this->data,
                     ],
                 ],
+                'hasTeam' => false,
                 'permission' => true,
             ],
             'edit user, success' => [
@@ -603,6 +640,7 @@ class UserTest extends TestCase
                         'userEdit' => $this->data,
                     ],
                 ],
+                'hasTeam' => false,
                 'permission' => true,
             ],
             'edit user with 2 roles, success' => [
@@ -619,6 +657,7 @@ class UserTest extends TestCase
                         'userEdit' => $this->data,
                     ],
                 ],
+                'hasTeam' => false,
                 'permission' => true,
             ],
             'text password less than 6 characters, expected error' => [
@@ -634,6 +673,7 @@ class UserTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $userEdit,
                 ],
+                'hasTeam' => false,
                 'permission' => true,
             ],
             'no text password, expected error' => [
@@ -649,6 +689,7 @@ class UserTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $userEdit,
                 ],
+                'hasTeam' => false,
                 'permission' => true,
             ],
             'text password with 6 characters, success' => [
@@ -665,6 +706,7 @@ class UserTest extends TestCase
                         'userEdit' => $this->data,
                     ],
                 ],
+                'hasTeam' => false,
                 'permission' => true,
             ],
             'email field is required, expected error' => [
@@ -680,6 +722,7 @@ class UserTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $userEdit,
                 ],
+                'hasTeam' => false,
                 'permission' => true,
             ],
             'email field is not unique, expected error' => [
@@ -694,6 +737,7 @@ class UserTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $userEdit,
                 ],
+                'hasTeam' => false,
                 'permission' => true,
             ],
             'email field is not email valid, expected error' => [
@@ -709,6 +753,7 @@ class UserTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $userEdit,
                 ],
+                'hasTeam' => false,
                 'permission' => true,
             ],
         ];

--- a/tests/Feature/GraphQL/UserTest.php
+++ b/tests/Feature/GraphQL/UserTest.php
@@ -84,8 +84,7 @@ class UserTest extends TestCase
         $expectedMessage,
         $expected,
         bool $permission
-    )
-    {
+    ) {
         $this->login = true;
 
         $this->checkPermission($permission, $this->permission, 'edit-user');
@@ -112,8 +111,8 @@ class UserTest extends TestCase
             $permission,
             $expectedMessage
         );
-        
-        if($permission) {
+
+        if ($permission) {
             $response->assertJsonStructure([
                 'data' => [
                     'user' => $this->data,

--- a/tests/Feature/GraphQL/UserTest.php
+++ b/tests/Feature/GraphQL/UserTest.php
@@ -345,7 +345,7 @@ class UserTest extends TestCase
                 [
                     'name' => $faker->name,
                     'email' => $faker->email,
-                    'roleId' => [1, 2],
+                    'roleId' => [1],
                     'password' => $password,
                 ],
                 'type_message_error' => 'roleId',
@@ -563,7 +563,7 @@ class UserTest extends TestCase
                     'name' => $faker->name,
                     'email' => $faker->email,
                     'password' => $password,
-                    'roleId' => [1, 2],
+                    'roleId' => [1],
                 ],
                 'type_message_error' => 'roleId',
                 'expected_message' => 'PermissionAssignment.validation_message_error',

--- a/tests/Feature/GraphQL/UserTest.php
+++ b/tests/Feature/GraphQL/UserTest.php
@@ -234,8 +234,6 @@ class UserTest extends TestCase
 
         $this->assertMessageError($typeMessageError, $response, $permission, $expectedMessage);
 
-        /* dump($expected);
-        dd($response->json()); */
         $response
             ->assertJsonStructure($expected)
             ->assertStatus(200);

--- a/tests/Feature/GraphQL/UserTest.php
+++ b/tests/Feature/GraphQL/UserTest.php
@@ -3,8 +3,8 @@
 namespace Tests\Feature\GraphQL;
 
 use App\Models\Position;
-use App\Models\User;
 use App\Models\Team;
+use App\Models\User;
 use Faker\Factory as Faker;
 use Tests\TestCase;
 
@@ -33,7 +33,7 @@ class UserTest extends TestCase
      * @author Maicon Cerutti
      *
      * @test
-     * 
+     *
      * @dataProvider listProvider
      *
      * @return void
@@ -43,8 +43,7 @@ class UserTest extends TestCase
         $expectedMessage,
         $expected,
         bool $permission
-    )
-    {
+    ) {
         $this->login = true;
 
         User::factory()
@@ -215,7 +214,7 @@ class UserTest extends TestCase
 
         $faker = Faker::create();
 
-        if($hasTeam) {
+        if ($hasTeam) {
             $team = Team::factory()->create();
             $parameters['teamId'] = $team->id;
         }
@@ -484,14 +483,13 @@ class UserTest extends TestCase
      * @return void
      */
     public function userEdit(
-        $parameters, 
-        $typeMessageError, 
-        $expectedMessage, 
-        $expected, 
+        $parameters,
+        $typeMessageError,
+        $expectedMessage,
+        $expected,
         bool $hasTeam,
         bool $permission
-        )
-    {
+        ) {
         $this->login = true;
 
         $this->checkPermission($permission, $this->permission, 'edit-user');
@@ -504,7 +502,7 @@ class UserTest extends TestCase
             ->has(Position::factory()->count(3))
             ->create();
 
-        if($hasTeam) {
+        if ($hasTeam) {
             $team = Team::factory()->create();
             $parameters['teamId'] = $team->id;
         }

--- a/tests/Feature/GraphQL/UserTest.php
+++ b/tests/Feature/GraphQL/UserTest.php
@@ -16,7 +16,9 @@ class UserTest extends TestCase
 
     protected $otherUser = false;
 
-    private $permission = 'technician';
+    protected $login = true;
+
+    private $role = 'technician';
 
     private $data = [
         'id',
@@ -26,6 +28,11 @@ class UserTest extends TestCase
         'createdAt',
         'updatedAt',
     ];
+
+    private function setPermissions(bool $hasPermission) {
+        $this->checkPermission($hasPermission, $this->role, 'edit-user');
+        $this->checkPermission($hasPermission, $this->role, 'view-user');
+    }
 
     /**
      * Listagem de todos os usuários.
@@ -42,16 +49,13 @@ class UserTest extends TestCase
         $typeMessageError,
         $expectedMessage,
         $expected,
-        bool $permission
+        bool $hasPermission
     ) {
-        $this->login = true;
+        $this->setPermissions($hasPermission);
 
         User::factory()
             ->has(Position::factory()->count(3))
             ->create();
-
-        $this->checkPermission($permission, $this->permission, 'edit-user');
-        $this->checkPermission($permission, $this->permission, 'view-user');
 
         $response = $this->graphQL(
             'users',
@@ -71,11 +75,11 @@ class UserTest extends TestCase
         $this->assertMessageError(
             $typeMessageError,
             $response,
-            $permission,
+            $hasPermission,
             $expectedMessage
         );
 
-        if ($permission) {
+        if ($hasPermission) {
             $response
                 ->assertJsonStructure($expected)
                 ->assertStatus(200);
@@ -129,12 +133,9 @@ class UserTest extends TestCase
         $typeMessageError,
         $expectedMessage,
         $expected,
-        bool $permission
+        bool $hasPermission
     ) {
-        $this->login = true;
-
-        $this->checkPermission($permission, $this->permission, 'edit-user');
-        $this->checkPermission($permission, $this->permission, 'view-user');
+        $this->setPermissions($hasPermission);
 
         $user = User::factory()
             ->has(Position::factory()->count(3))
@@ -154,11 +155,11 @@ class UserTest extends TestCase
         $this->assertMessageError(
             $typeMessageError,
             $response,
-            $permission,
+            $hasPermission,
             $expectedMessage
         );
 
-        if ($permission) {
+        if ($hasPermission) {
             $response->assertJsonStructure($expected)
                 ->assertStatus(200);
         }
@@ -208,9 +209,9 @@ class UserTest extends TestCase
         $expectedMessage,
         $expected,
         bool $hasTeam,
-        bool $permission
+        bool $hasPermission
         ) {
-        $this->login = true;
+        $this->setPermissions($hasPermission);
 
         $faker = Faker::create();
 
@@ -218,8 +219,6 @@ class UserTest extends TestCase
             $team = Team::factory()->create();
             $parameters['teamId'] = $team->id;
         }
-
-        $this->checkPermission($permission, $this->permission, 'edit-user');
 
         $parameters['name'] = $faker->name;
 
@@ -232,7 +231,7 @@ class UserTest extends TestCase
             true
         );
 
-        $this->assertMessageError($typeMessageError, $response, $permission, $expectedMessage);
+        $this->assertMessageError($typeMessageError, $response, $hasPermission, $expectedMessage);
 
         $response
             ->assertJsonStructure($expected)
@@ -486,11 +485,9 @@ class UserTest extends TestCase
         $expectedMessage,
         $expected,
         bool $hasTeam,
-        bool $permission
+        bool $hasPermission
         ) {
-        $this->login = true;
-
-        $this->checkPermission($permission, $this->permission, 'edit-user');
+        $this->setPermissions($hasPermission);
 
         $userExist = User::factory()
             ->has(Position::factory()->count(3))
@@ -520,7 +517,7 @@ class UserTest extends TestCase
             true
         );
 
-        $this->assertMessageError($typeMessageError, $response, $permission, $expectedMessage);
+        $this->assertMessageError($typeMessageError, $response, $hasPermission, $expectedMessage);
 
         $response
             ->assertJsonStructure($expected)
@@ -766,11 +763,9 @@ class UserTest extends TestCase
      *
      * @return void
      */
-    public function testDeleteUser($data, $typeMessageError, $expectedMessage, $expected, $permission)
+    public function testDeleteUser($data, $typeMessageError, $expectedMessage, $expected, $hasPermission)
     {
-        $this->login = true;
-
-        $this->checkPermission($permission, $this->permission, 'edit-user');
+        $this->setPermissions($hasPermission);
 
         $user = User::factory()
             ->has(Position::factory()->count(3))
@@ -791,7 +786,7 @@ class UserTest extends TestCase
             true
         );
 
-        $this->assertMessageError($typeMessageError, $response, $permission, $expectedMessage);
+        $this->assertMessageError($typeMessageError, $response, $hasPermission, $expectedMessage);
 
         $response
             ->assertJsonStructure($expected)

--- a/tests/Feature/GraphQL/UserTest.php
+++ b/tests/Feature/GraphQL/UserTest.php
@@ -105,7 +105,7 @@ class UserTest extends TestCase
                         ],
                     ],
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'without permission' => [
                 'type_message_error' => 'message',
@@ -113,7 +113,7 @@ class UserTest extends TestCase
                 'expected' => [
                     'errors' => $this->errors,
                 ],
-                'permission' => false,
+                'hasPermission' => false,
             ],
         ];
     }
@@ -179,7 +179,7 @@ class UserTest extends TestCase
                         'user' => $this->data,
                     ],
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'without permission' => [
                 'type_message_error' => 'message',
@@ -187,7 +187,7 @@ class UserTest extends TestCase
                 'expected' => [
                     'errors' => $this->errors,
                 ],
-                'permission' => false,
+                'hasPermission' => false,
             ],
         ];
     }
@@ -267,7 +267,7 @@ class UserTest extends TestCase
                     ],
                 ],
                 'hasTeam' => true,
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'create user with position, success' => [
                 [
@@ -285,7 +285,7 @@ class UserTest extends TestCase
                     ],
                 ],
                 'hasTeam' => false,
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'declare roleId is required, expected error' => [
                 [
@@ -301,7 +301,7 @@ class UserTest extends TestCase
                     'data' => $userCreate,
                 ],
                 'hasTeam' => false,
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'create user, success' => [
                 [
@@ -318,7 +318,7 @@ class UserTest extends TestCase
                     ],
                 ],
                 'hasTeam' => false,
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'create user with 2 roles, success' => [
                 [
@@ -335,7 +335,7 @@ class UserTest extends TestCase
                     ],
                 ],
                 'hasTeam' => false,
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'create user with permission that shouldnt have, expected error' => [
                 [
@@ -351,7 +351,7 @@ class UserTest extends TestCase
                     'data' => $userCreate,
                 ],
                 'hasTeam' => false,
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'create user without permission, expected error' => [
                 [
@@ -367,7 +367,7 @@ class UserTest extends TestCase
                     'data' => $userCreate,
                 ],
                 'hasTeam' => false,
-                'permission' => false,
+                'hasPermission' => false,
             ],
             'text password less than 6 characters, expected error' => [
                 [
@@ -383,7 +383,7 @@ class UserTest extends TestCase
                     'data' => $userCreate,
                 ],
                 'hasTeam' => false,
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'no text password, expected error' => [
                 [
@@ -398,7 +398,7 @@ class UserTest extends TestCase
                     'data' => $userCreate,
                 ],
                 'hasTeam' => false,
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'text password with 6 characters, success' => [
                 [
@@ -415,7 +415,7 @@ class UserTest extends TestCase
                     ],
                 ],
                 'hasTeam' => false,
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'email field is required, expected error' => [
                 [
@@ -431,7 +431,7 @@ class UserTest extends TestCase
                     'data' => $userCreate,
                 ],
                 'hasTeam' => false,
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'email field is not unique, expected error' => [
                 [
@@ -447,7 +447,7 @@ class UserTest extends TestCase
                     'data' => $userCreate,
                 ],
                 'hasTeam' => false,
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'email field is not email valid, expected error' => [
                 [
@@ -463,7 +463,7 @@ class UserTest extends TestCase
                     'data' => $userCreate,
                 ],
                 'hasTeam' => false,
-                'permission' => true,
+                'hasPermission' => true,
             ],
         ];
     }
@@ -549,7 +549,7 @@ class UserTest extends TestCase
                     'data' => $userEdit,
                 ],
                 'hasTeam' => false,
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'edit user with permission that shouldnt have, expected error' => [
                 [
@@ -565,7 +565,7 @@ class UserTest extends TestCase
                     'data' => $userEdit,
                 ],
                 'hasTeam' => false,
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'edit user without permission, expected error' => [
                 [
@@ -581,7 +581,7 @@ class UserTest extends TestCase
                     'data' => $userEdit,
                 ],
                 'hasTeam' => false,
-                'permission' => false,
+                'hasPermission' => false,
             ],
             'edit user with team, success' => [
                 [
@@ -599,7 +599,7 @@ class UserTest extends TestCase
                     ],
                 ],
                 'hasTeam' => true,
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'edit user with position, success' => [
                 [
@@ -617,7 +617,7 @@ class UserTest extends TestCase
                     ],
                 ],
                 'hasTeam' => false,
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'edit user, success' => [
                 [
@@ -634,7 +634,7 @@ class UserTest extends TestCase
                     ],
                 ],
                 'hasTeam' => false,
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'edit user with 2 roles, success' => [
                 [
@@ -651,7 +651,7 @@ class UserTest extends TestCase
                     ],
                 ],
                 'hasTeam' => false,
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'text password less than 6 characters, expected error' => [
                 [
@@ -667,7 +667,7 @@ class UserTest extends TestCase
                     'data' => $userEdit,
                 ],
                 'hasTeam' => false,
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'no text password, expected error' => [
                 [
@@ -683,7 +683,7 @@ class UserTest extends TestCase
                     'data' => $userEdit,
                 ],
                 'hasTeam' => false,
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'text password with 6 characters, success' => [
                 [
@@ -700,7 +700,7 @@ class UserTest extends TestCase
                     ],
                 ],
                 'hasTeam' => false,
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'email field is required, expected error' => [
                 [
@@ -716,7 +716,7 @@ class UserTest extends TestCase
                     'data' => $userEdit,
                 ],
                 'hasTeam' => false,
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'email field is not unique, expected error' => [
                 [
@@ -731,7 +731,7 @@ class UserTest extends TestCase
                     'data' => $userEdit,
                 ],
                 'hasTeam' => false,
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'email field is not email valid, expected error' => [
                 [
@@ -747,7 +747,7 @@ class UserTest extends TestCase
                     'data' => $userEdit,
                 ],
                 'hasTeam' => false,
-                'permission' => true,
+                'hasPermission' => true,
             ],
         ];
     }
@@ -810,7 +810,7 @@ class UserTest extends TestCase
                 'expected' => [
                     'data' => $userDelete,
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
             'delete user without permission, expected error' => [
                 [
@@ -822,7 +822,7 @@ class UserTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $userDelete,
                 ],
-                'permission' => false,
+                'hasPermission' => false,
             ],
             'delete user that does not exist, expected error' => [
                 [
@@ -834,7 +834,7 @@ class UserTest extends TestCase
                     'errors' => $this->errors,
                     'data' => $userDelete,
                 ],
-                'permission' => true,
+                'hasPermission' => true,
             ],
         ];
     }

--- a/tests/Feature/GraphQL/UserTest.php
+++ b/tests/Feature/GraphQL/UserTest.php
@@ -15,7 +15,7 @@ class UserTest extends TestCase
 
     protected $otherUser = false;
 
-    private $permission = 'Técnico';
+    private $permission = 'technician';
 
     private $data = [
         'id',
@@ -123,7 +123,7 @@ class UserTest extends TestCase
 
         $faker = Faker::create();
 
-        $this->checkPermission($permission, $this->permission, 'create-user');
+        $this->checkPermission($permission, $this->permission, 'edit-user');
 
         $parameters['name'] = $faker->name;
 
@@ -639,7 +639,7 @@ class UserTest extends TestCase
     {
         $this->login = true;
 
-        $this->checkPermission($permission, $this->permission, 'delete-user');
+        $this->checkPermission($permission, $this->permission, 'edit-user');
 
         $user = User::factory()
             ->has(Position::factory()->count(3))

--- a/tests/Feature/GraphQL/UserTest.php
+++ b/tests/Feature/GraphQL/UserTest.php
@@ -29,7 +29,8 @@ class UserTest extends TestCase
         'updatedAt',
     ];
 
-    private function setPermissions(bool $hasPermission) {
+    private function setPermissions(bool $hasPermission)
+    {
         $this->checkPermission($hasPermission, $this->role, 'edit-user');
         $this->checkPermission($hasPermission, $this->role, 'view-user');
     }

--- a/tests/Feature/GraphQL/UserTest.php
+++ b/tests/Feature/GraphQL/UserTest.php
@@ -32,10 +32,17 @@ class UserTest extends TestCase
      * @author Maicon Cerutti
      *
      * @test
+     * 
+     * @dataProvider listProvider
      *
      * @return void
      */
-    public function usersList()
+    public function usersList(
+        $typeMessageError,
+        $expectedMessage,
+        $expected,
+        bool $permission
+    )
     {
         $this->login = true;
 
@@ -43,7 +50,10 @@ class UserTest extends TestCase
             ->has(Position::factory()->count(3))
             ->create();
 
-        $this->graphQL(
+        $this->checkPermission($permission, $this->permission, 'edit-user');
+        $this->checkPermission($permission, $this->permission, 'view-user');
+
+        $response = $this->graphQL(
             'users',
             [
                 'name' => '%%',
@@ -56,16 +66,52 @@ class UserTest extends TestCase
             ],
             'query',
             false
-        )->assertJsonStructure([
-            'data' => [
-                'users' => [
-                    'paginatorInfo' => $this->paginatorInfo,
+        );
+
+        $this->assertMessageError(
+            $typeMessageError,
+            $response,
+            $permission,
+            $expectedMessage
+        );
+
+        if ($permission) {
+            $response
+                ->assertJsonStructure($expected)
+                ->assertStatus(200);
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function listProvider()
+    {
+        return [
+            'with permission' => [
+                'type_message_error' => false,
+                'expected_message' => false,
+                'expected' => [
                     'data' => [
-                        '*' => $this->data,
+                        'users' => [
+                            'paginatorInfo' => $this->paginatorInfo,
+                            'data' => [
+                                '*' => $this->data,
+                            ],
+                        ],
                     ],
                 ],
+                'permission' => true,
             ],
-        ])->assertStatus(200);
+            'without permission' => [
+                'type_message_error' => 'message',
+                'expected_message' => $this->unauthorized,
+                'expected' => [
+                    'errors' => $this->errors,
+                ],
+                'permission' => false,
+            ],
+        ];
     }
 
     /**
@@ -113,11 +159,8 @@ class UserTest extends TestCase
         );
 
         if ($permission) {
-            $response->assertJsonStructure([
-                'data' => [
-                    'user' => $this->data,
-                ],
-            ])->assertStatus(200);
+            $response->assertJsonStructure($expected)
+                ->assertStatus(200);
         }
     }
 
@@ -132,7 +175,7 @@ class UserTest extends TestCase
                 'expected_message' => false,
                 'expected' => [
                     'data' => [
-                        'config' => $this->data,
+                        'user' => $this->data,
                     ],
                 ],
                 'permission' => true,

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -329,7 +329,7 @@ abstract class TestCase extends BaseTestCase
                 if (isset($response['validation'])) {
                     $this->assertSame($response['validation'][$type_message_error][0], trans($expected_message));
                 } else {
-                    if(isset($response['category'])) {
+                    if (isset($response['category'])) {
                         $this->assertSame($response['category'], trans($expected_message));
                     }
                 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -329,7 +329,9 @@ abstract class TestCase extends BaseTestCase
                 if (isset($response['validation'])) {
                     $this->assertSame($response['validation'][$type_message_error][0], trans($expected_message));
                 } else {
-                    $this->assertSame($response['category'], trans($expected_message));
+                    if(isset($response['category'])) {
+                        $this->assertSame($response['category'], trans($expected_message));
+                    }
                 }
             }
         }

--- a/tests/Unit/App/Models/TeamsUsersTest.php
+++ b/tests/Unit/App/Models/TeamsUsersTest.php
@@ -40,7 +40,7 @@ class TeamsUsersTest extends TestCase
                 ->with(1)
                 ->andReturn($mock);
             $mock->shouldReceive('hasRole')
-                ->with('Técnico')
+                ->with('technician')
                 ->once()->andReturn($data['user_relation_team_technian']);
         });
 

--- a/tests/Unit/App/Models/UserTest.php
+++ b/tests/Unit/App/Models/UserTest.php
@@ -58,27 +58,27 @@ class UserTest extends TestCase
     {
         return [
             'has permission' => [
-                'namePermission' => 'list-role-administrador',
-                'permissions' => ['list-role-administrador'],
+                'namePermission' => 'view-role-admin',
+                'permissions' => ['view-role-admin'],
                 'expected' => true,
             ],
             'has permission and with more than one permissions' => [
-                'namePermission' => 'list-role-administrador',
-                'permissions' => ['list-role-administrador', 'list-role-technician', 'list-role-player'],
+                'namePermission' => 'view-role-admin',
+                'permissions' => ['view-role-admin', 'list-role-technician', 'list-role-player'],
                 'expected' => true,
             ],
             'not has permission' => [
-                'namePermission' => 'list-role-administrador',
+                'namePermission' => 'view-role-admin',
                 'permissions' => ['list-role-player'],
                 'expected' => false,
             ],
             'not has permission and no permission' => [
-                'namePermission' => 'list-role-administrador',
+                'namePermission' => 'view-role-admin',
                 'permissions' => [],
                 'expected' => false,
             ],
             'not has permission and with more than one permissions' => [
-                'namePermission' => 'list-role-administrador',
+                'namePermission' => 'view-role-admin',
                 'permissions' => ['list-role-technician', 'list-role-player', 'list-role-player'],
                 'expected' => false,
             ],
@@ -105,7 +105,7 @@ class UserTest extends TestCase
         $this->be($userMock);
 
         $user = new User();
-        $user->hasPermissionRole('list-role-administrador');
+        $user->hasPermissionRole('view-role-admin');
     }
 
     /**

--- a/tests/Unit/App/Policies/ConfigPolicyTest.php
+++ b/tests/Unit/App/Policies/ConfigPolicyTest.php
@@ -4,8 +4,8 @@ namespace Tests\Unit\App\Policies;
 
 use App\Models\User;
 use App\Policies\ConfigPolicy;
-use Tests\TestCase;
 use Mockery\MockInterface;
+use Tests\TestCase;
 
 class ConfigPolicyTest extends TestCase
 {

--- a/tests/Unit/App/Policies/ConfigPolicyTest.php
+++ b/tests/Unit/App/Policies/ConfigPolicyTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\App\Policies;
 use App\Models\User;
 use App\Policies\ConfigPolicy;
 use Tests\TestCase;
+use Mockery\MockInterface;
 
 class ConfigPolicyTest extends TestCase
 {
@@ -17,7 +18,7 @@ class ConfigPolicyTest extends TestCase
      *
      * @return void
      */
-    public function edit(bool $expected): void
+    public function permissionEdit(bool $expected): void
     {
         $user = $this->createMock(User::class);
         $user->expects($this->once())
@@ -25,7 +26,33 @@ class ConfigPolicyTest extends TestCase
             ->with('edit-config')
             ->willReturn($expected);
 
-        $fundamentalPolicy = new ConfigPolicy();
-        $fundamentalPolicy->edit($user);
+        $configPolicy = new ConfigPolicy();
+        $configPolicy->edit($user);
+    }
+
+    /**
+     * A basic unit test view.
+     *
+     * @dataProvider permissionProvider
+     *
+     * @test
+     *
+     * @return void
+     */
+    public function permissionView(bool $expected): void
+    {
+        $userMock = $this->mock(User::class, function (MockInterface $mock) use ($expected) {
+            $mock->shouldReceive('hasPermissionTo')
+                ->with('edit-config')
+                ->andReturn($expected);
+
+            $mock->shouldReceive('hasPermissionTo')
+                ->with('view-config')
+                ->andReturn($expected);
+        });
+
+        $configPolicy = new ConfigPolicy();
+
+        $this->assertEquals($expected, $configPolicy->view($userMock));
     }
 }

--- a/tests/Unit/App/Policies/FundamentalPolicyTest.php
+++ b/tests/Unit/App/Policies/FundamentalPolicyTest.php
@@ -5,6 +5,8 @@ namespace Tests\Unit\App\Policies;
 use App\Models\User;
 use App\Policies\FundamentalPolicy;
 use Tests\TestCase;
+use Mockery\MockInterface;
+
 
 class FundamentalPolicyTest extends TestCase
 {
@@ -38,7 +40,7 @@ class FundamentalPolicyTest extends TestCase
      *
      * @return void
      */
-    public function edit(bool $expected): void
+    public function permissionEdit(bool $expected): void
     {
         $user = $this->createMock(User::class);
         $user->expects($this->once())
@@ -59,7 +61,7 @@ class FundamentalPolicyTest extends TestCase
      *
      * @return void
      */
-    public function deleteFundamentalPolicy(bool $expected): void
+    public function permissionDelete(bool $expected): void
     {
         $user = $this->createMock(User::class);
         $user->expects($this->once())
@@ -69,5 +71,32 @@ class FundamentalPolicyTest extends TestCase
 
         $fundamentalPolicy = new FundamentalPolicy();
         $fundamentalPolicy->delete($user);
+    }
+
+    /**
+     * A basic unit test view.
+     *
+     * @dataProvider permissionProvider
+     *
+     * @test
+     *
+     * @return void
+     */
+    public function permissionView(bool $expected): void
+    {
+        $userMock = $this->mock(User::class, function (MockInterface $mock) use ($expected) {
+            $mock->shouldReceive('hasPermissionTo')
+                ->with('edit-fundamental')
+                ->andReturn($expected);
+
+            $mock->shouldReceive('hasPermissionTo')
+                ->with('view-fundamental')
+                ->andReturn($expected);
+        });
+
+        $fundamentalPolicy = new FundamentalPolicy();
+        $return = $fundamentalPolicy->view($userMock);
+        
+        $this->assertEquals($expected, $return);
     }
 }

--- a/tests/Unit/App/Policies/FundamentalPolicyTest.php
+++ b/tests/Unit/App/Policies/FundamentalPolicyTest.php
@@ -4,9 +4,8 @@ namespace Tests\Unit\App\Policies;
 
 use App\Models\User;
 use App\Policies\FundamentalPolicy;
-use Tests\TestCase;
 use Mockery\MockInterface;
-
+use Tests\TestCase;
 
 class FundamentalPolicyTest extends TestCase
 {
@@ -96,7 +95,7 @@ class FundamentalPolicyTest extends TestCase
 
         $fundamentalPolicy = new FundamentalPolicy();
         $return = $fundamentalPolicy->view($userMock);
-        
+
         $this->assertEquals($expected, $return);
     }
 }

--- a/tests/Unit/App/Policies/FundamentalPolicyTest.php
+++ b/tests/Unit/App/Policies/FundamentalPolicyTest.php
@@ -22,7 +22,7 @@ class FundamentalPolicyTest extends TestCase
         $user = $this->createMock(User::class);
         $user->expects($this->once())
             ->method('hasPermissionTo')
-            ->with('create-fundamental')
+            ->with('edit-fundamental')
             ->willReturn($expected);
 
         $fundamentalPolicy = new FundamentalPolicy();

--- a/tests/Unit/App/Policies/FundamentalPolicyTest.php
+++ b/tests/Unit/App/Policies/FundamentalPolicyTest.php
@@ -64,7 +64,7 @@ class FundamentalPolicyTest extends TestCase
         $user = $this->createMock(User::class);
         $user->expects($this->once())
             ->method('hasPermissionTo')
-            ->with('delete-fundamental')
+            ->with('edit-fundamental')
             ->willReturn($expected);
 
         $fundamentalPolicy = new FundamentalPolicy();

--- a/tests/Unit/App/Policies/PositionPolicyTest.php
+++ b/tests/Unit/App/Policies/PositionPolicyTest.php
@@ -64,7 +64,7 @@ class PositionPolicyTest extends TestCase
         $user = $this->createMock(User::class);
         $user->expects($this->once())
             ->method('hasPermissionTo')
-            ->with('delete-position')
+            ->with('edit-position')
             ->willReturn($expected);
 
         $positionPolicy = new PositionPolicy();

--- a/tests/Unit/App/Policies/PositionPolicyTest.php
+++ b/tests/Unit/App/Policies/PositionPolicyTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\App\Policies;
 use App\Models\User;
 use App\Policies\PositionPolicy;
 use Tests\TestCase;
+use Mockery\MockInterface;
 
 class PositionPolicyTest extends TestCase
 {
@@ -17,7 +18,7 @@ class PositionPolicyTest extends TestCase
      *
      * @return void
      */
-    public function create(bool $expected): void
+    public function permissionCreate(bool $expected): void
     {
         $user = $this->createMock(User::class);
         $user->expects($this->once())
@@ -38,7 +39,7 @@ class PositionPolicyTest extends TestCase
      *
      * @return void
      */
-    public function edit(bool $expected): void
+    public function permissionEdit(bool $expected): void
     {
         $user = $this->createMock(User::class);
         $user->expects($this->once())
@@ -59,7 +60,7 @@ class PositionPolicyTest extends TestCase
      *
      * @return void
      */
-    public function deletePositionPolicy(bool $expected): void
+    public function permissionDelete(bool $expected): void
     {
         $user = $this->createMock(User::class);
         $user->expects($this->once())
@@ -69,5 +70,32 @@ class PositionPolicyTest extends TestCase
 
         $positionPolicy = new PositionPolicy();
         $positionPolicy->delete($user);
+    }
+
+    /**
+     * A basic unit test view.
+     *
+     * @dataProvider permissionProvider
+     *
+     * @test
+     *
+     * @return void
+     */
+    public function permissionView(bool $expected): void
+    {
+        $userMock = $this->mock(User::class, function (MockInterface $mock) use ($expected) {
+            $mock->shouldReceive('hasPermissionTo')
+                ->with('edit-position')
+                ->andReturn($expected);
+
+            $mock->shouldReceive('hasPermissionTo')
+                ->with('view-position')
+                ->andReturn($expected);
+        });
+
+        $positionPolicy = new PositionPolicy();
+
+        $this->assertEquals($expected, $positionPolicy->view($userMock));
+
     }
 }

--- a/tests/Unit/App/Policies/PositionPolicyTest.php
+++ b/tests/Unit/App/Policies/PositionPolicyTest.php
@@ -4,8 +4,8 @@ namespace Tests\Unit\App\Policies;
 
 use App\Models\User;
 use App\Policies\PositionPolicy;
-use Tests\TestCase;
 use Mockery\MockInterface;
+use Tests\TestCase;
 
 class PositionPolicyTest extends TestCase
 {
@@ -96,6 +96,5 @@ class PositionPolicyTest extends TestCase
         $positionPolicy = new PositionPolicy();
 
         $this->assertEquals($expected, $positionPolicy->view($userMock));
-
     }
 }

--- a/tests/Unit/App/Policies/PositionPolicyTest.php
+++ b/tests/Unit/App/Policies/PositionPolicyTest.php
@@ -22,7 +22,7 @@ class PositionPolicyTest extends TestCase
         $user = $this->createMock(User::class);
         $user->expects($this->once())
             ->method('hasPermissionTo')
-            ->with('create-position')
+            ->with('edit-position')
             ->willReturn($expected);
 
         $positionPolicy = new PositionPolicy();

--- a/tests/Unit/App/Policies/SpecificFundamentalPolicyTest.php
+++ b/tests/Unit/App/Policies/SpecificFundamentalPolicyTest.php
@@ -64,7 +64,7 @@ class SpecificFundamentalPolicyTest extends TestCase
         $user = $this->createMock(User::class);
         $user->expects($this->once())
             ->method('hasPermissionTo')
-            ->with('delete-specific-fundamental')
+            ->with('edit-specific-fundamental')
             ->willReturn($expected);
 
         $specificFundamentalPolicy = new SpecificFundamentalPolicy();

--- a/tests/Unit/App/Policies/SpecificFundamentalPolicyTest.php
+++ b/tests/Unit/App/Policies/SpecificFundamentalPolicyTest.php
@@ -4,8 +4,8 @@ namespace Tests\Unit\App\Policies;
 
 use App\Models\User;
 use App\Policies\SpecificFundamentalPolicy;
-use Tests\TestCase;
 use Mockery\MockInterface;
+use Tests\TestCase;
 
 class SpecificFundamentalPolicyTest extends TestCase
 {
@@ -94,7 +94,7 @@ class SpecificFundamentalPolicyTest extends TestCase
         });
 
         $specificFundamentalPolicy = new SpecificFundamentalPolicy();
-        
+
         $this->assertEquals($expected, $specificFundamentalPolicy->view($userMock));
     }
 }

--- a/tests/Unit/App/Policies/SpecificFundamentalPolicyTest.php
+++ b/tests/Unit/App/Policies/SpecificFundamentalPolicyTest.php
@@ -22,7 +22,7 @@ class SpecificFundamentalPolicyTest extends TestCase
         $user = $this->createMock(User::class);
         $user->expects($this->once())
             ->method('hasPermissionTo')
-            ->with('create-specific-fundamental')
+            ->with('edit-specific-fundamental')
             ->willReturn($expected);
 
         $specificFundamentalPolicy = new SpecificFundamentalPolicy();

--- a/tests/Unit/App/Policies/SpecificFundamentalPolicyTest.php
+++ b/tests/Unit/App/Policies/SpecificFundamentalPolicyTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\App\Policies;
 use App\Models\User;
 use App\Policies\SpecificFundamentalPolicy;
 use Tests\TestCase;
+use Mockery\MockInterface;
 
 class SpecificFundamentalPolicyTest extends TestCase
 {
@@ -17,7 +18,7 @@ class SpecificFundamentalPolicyTest extends TestCase
      *
      * @return void
      */
-    public function create(bool $expected): void
+    public function permissionCreate(bool $expected): void
     {
         $user = $this->createMock(User::class);
         $user->expects($this->once())
@@ -38,7 +39,7 @@ class SpecificFundamentalPolicyTest extends TestCase
      *
      * @return void
      */
-    public function edit(bool $expected): void
+    public function permissionEdit(bool $expected): void
     {
         $user = $this->createMock(User::class);
         $user->expects($this->once())
@@ -59,7 +60,7 @@ class SpecificFundamentalPolicyTest extends TestCase
      *
      * @return void
      */
-    public function deleteSpecificFundamentalPolicy(bool $expected): void
+    public function permissionDelete(bool $expected): void
     {
         $user = $this->createMock(User::class);
         $user->expects($this->once())
@@ -69,5 +70,31 @@ class SpecificFundamentalPolicyTest extends TestCase
 
         $specificFundamentalPolicy = new SpecificFundamentalPolicy();
         $specificFundamentalPolicy->delete($user);
+    }
+
+    /**
+     * A basic unit test view.
+     *
+     * @dataProvider permissionProvider
+     *
+     * @test
+     *
+     * @return void
+     */
+    public function permissionView(bool $expected): void
+    {
+        $userMock = $this->mock(User::class, function (MockInterface $mock) use ($expected) {
+            $mock->shouldReceive('hasPermissionTo')
+                ->with('edit-specific-fundamental')
+                ->andReturn($expected);
+
+            $mock->shouldReceive('hasPermissionTo')
+                ->with('view-specific-fundamental')
+                ->andReturn($expected);
+        });
+
+        $specificFundamentalPolicy = new SpecificFundamentalPolicy();
+        
+        $this->assertEquals($expected, $specificFundamentalPolicy->view($userMock));
     }
 }

--- a/tests/Unit/App/Policies/TeamPolicyTest.php
+++ b/tests/Unit/App/Policies/TeamPolicyTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\App\Policies;
 use App\Models\User;
 use App\Policies\TeamPolicy;
 use Tests\TestCase;
+use Mockery\MockInterface;
 
 class TeamPolicyTest extends TestCase
 {
@@ -17,7 +18,7 @@ class TeamPolicyTest extends TestCase
      *
      * @return void
      */
-    public function create(bool $expected): void
+    public function permissionCreate(bool $expected): void
     {
         $user = $this->createMock(User::class);
         $user->expects($this->once())
@@ -38,7 +39,7 @@ class TeamPolicyTest extends TestCase
      *
      * @return void
      */
-    public function edit(bool $expected): void
+    public function permissionEdit(bool $expected): void
     {
         $user = $this->createMock(User::class);
         $user->expects($this->once())
@@ -59,7 +60,7 @@ class TeamPolicyTest extends TestCase
      *
      * @return void
      */
-    public function deleteTeamPolicy(bool $expected): void
+    public function permissionDelete(bool $expected): void
     {
         $user = $this->createMock(User::class);
         $user->expects($this->once())
@@ -69,5 +70,31 @@ class TeamPolicyTest extends TestCase
 
         $teamPolicy = new TeamPolicy();
         $teamPolicy->delete($user);
+    }
+
+    /**
+     * A basic unit test view.
+     *
+     * @dataProvider permissionProvider
+     *
+     * @test
+     *
+     * @return void
+     */
+    public function permissionView(bool $expected): void
+    {
+        $userMock = $this->mock(User::class, function (MockInterface $mock) use ($expected) {
+            $mock->shouldReceive('hasPermissionTo')
+                ->with('edit-team')
+                ->andReturn($expected);
+
+            $mock->shouldReceive('hasPermissionTo')
+                ->with('view-team')
+                ->andReturn($expected);
+        });
+
+        $teamPolicy = new TeamPolicy();
+        
+        $this->assertEquals($expected, $teamPolicy->view($userMock));
     }
 }

--- a/tests/Unit/App/Policies/TeamPolicyTest.php
+++ b/tests/Unit/App/Policies/TeamPolicyTest.php
@@ -22,7 +22,7 @@ class TeamPolicyTest extends TestCase
         $user = $this->createMock(User::class);
         $user->expects($this->once())
             ->method('hasPermissionTo')
-            ->with('create-team')
+            ->with('edit-team')
             ->willReturn($expected);
 
         $teamPolicy = new TeamPolicy();

--- a/tests/Unit/App/Policies/TeamPolicyTest.php
+++ b/tests/Unit/App/Policies/TeamPolicyTest.php
@@ -64,7 +64,7 @@ class TeamPolicyTest extends TestCase
         $user = $this->createMock(User::class);
         $user->expects($this->once())
             ->method('hasPermissionTo')
-            ->with('delete-team')
+            ->with('edit-team')
             ->willReturn($expected);
 
         $teamPolicy = new TeamPolicy();

--- a/tests/Unit/App/Policies/TeamPolicyTest.php
+++ b/tests/Unit/App/Policies/TeamPolicyTest.php
@@ -4,8 +4,8 @@ namespace Tests\Unit\App\Policies;
 
 use App\Models\User;
 use App\Policies\TeamPolicy;
-use Tests\TestCase;
 use Mockery\MockInterface;
+use Tests\TestCase;
 
 class TeamPolicyTest extends TestCase
 {
@@ -94,7 +94,7 @@ class TeamPolicyTest extends TestCase
         });
 
         $teamPolicy = new TeamPolicy();
-        
+
         $this->assertEquals($expected, $teamPolicy->view($userMock));
     }
 }

--- a/tests/Unit/App/Policies/TrainingConfigPolicyTest.php
+++ b/tests/Unit/App/Policies/TrainingConfigPolicyTest.php
@@ -4,8 +4,8 @@ namespace Tests\Unit\App\Policies;
 
 use App\Models\User;
 use App\Policies\TrainingConfigPolicy;
-use Tests\TestCase;
 use Mockery\MockInterface;
+use Tests\TestCase;
 
 class TrainingConfigPolicyTest extends TestCase
 {
@@ -52,7 +52,7 @@ class TrainingConfigPolicyTest extends TestCase
         });
 
         $trainingConfigPolicy = new TrainingConfigPolicy();
-        
+
         $this->assertEquals($expected, $trainingConfigPolicy->view($userMock));
     }
 }

--- a/tests/Unit/App/Policies/TrainingConfigPolicyTest.php
+++ b/tests/Unit/App/Policies/TrainingConfigPolicyTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\App\Policies;
 use App\Models\User;
 use App\Policies\TrainingConfigPolicy;
 use Tests\TestCase;
+use Mockery\MockInterface;
 
 class TrainingConfigPolicyTest extends TestCase
 {
@@ -17,7 +18,7 @@ class TrainingConfigPolicyTest extends TestCase
      *
      * @return void
      */
-    public function edit(bool $expected): void
+    public function permissionEdit(bool $expected): void
     {
         $user = $this->createMock(User::class);
         $user->expects($this->once())
@@ -27,5 +28,31 @@ class TrainingConfigPolicyTest extends TestCase
 
         $trainingPolicy = new TrainingConfigPolicy();
         $trainingPolicy->edit($user);
+    }
+
+    /**
+     * A basic unit test view.
+     *
+     * @dataProvider permissionProvider
+     *
+     * @test
+     *
+     * @return void
+     */
+    public function permissionView(bool $expected): void
+    {
+        $userMock = $this->mock(User::class, function (MockInterface $mock) use ($expected) {
+            $mock->shouldReceive('hasPermissionTo')
+                ->with('edit-training-config')
+                ->andReturn($expected);
+
+            $mock->shouldReceive('hasPermissionTo')
+                ->with('view-training-config')
+                ->andReturn($expected);
+        });
+
+        $trainingConfigPolicy = new TrainingConfigPolicy();
+        
+        $this->assertEquals($expected, $trainingConfigPolicy->view($userMock));
     }
 }

--- a/tests/Unit/App/Policies/TrainingPolicyTest.php
+++ b/tests/Unit/App/Policies/TrainingPolicyTest.php
@@ -64,7 +64,7 @@ class TrainingPolicyTest extends TestCase
         $user = $this->createMock(User::class);
         $user->expects($this->once())
             ->method('hasPermissionTo')
-            ->with('delete-training')
+            ->with('edit-training')
             ->willReturn($expected);
 
         $teamPolicy = new TrainingPolicy();

--- a/tests/Unit/App/Policies/TrainingPolicyTest.php
+++ b/tests/Unit/App/Policies/TrainingPolicyTest.php
@@ -4,8 +4,8 @@ namespace Tests\Unit\App\Policies;
 
 use App\Models\User;
 use App\Policies\TrainingPolicy;
-use Tests\TestCase;
 use Mockery\MockInterface;
+use Tests\TestCase;
 
 class TrainingPolicyTest extends TestCase
 {

--- a/tests/Unit/App/Policies/TrainingPolicyTest.php
+++ b/tests/Unit/App/Policies/TrainingPolicyTest.php
@@ -22,7 +22,7 @@ class TrainingPolicyTest extends TestCase
         $user = $this->createMock(User::class);
         $user->expects($this->once())
             ->method('hasPermissionTo')
-            ->with('create-training')
+            ->with('edit-training')
             ->willReturn($expected);
 
         $teamPolicy = new TrainingPolicy();

--- a/tests/Unit/App/Policies/TrainingPolicyTest.php
+++ b/tests/Unit/App/Policies/TrainingPolicyTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\App\Policies;
 use App\Models\User;
 use App\Policies\TrainingPolicy;
 use Tests\TestCase;
+use Mockery\MockInterface;
 
 class TrainingPolicyTest extends TestCase
 {
@@ -17,7 +18,7 @@ class TrainingPolicyTest extends TestCase
      *
      * @return void
      */
-    public function create(bool $expected): void
+    public function permissionCreate(bool $expected): void
     {
         $user = $this->createMock(User::class);
         $user->expects($this->once())
@@ -38,7 +39,7 @@ class TrainingPolicyTest extends TestCase
      *
      * @return void
      */
-    public function edit(bool $expected): void
+    public function permissionEdit(bool $expected): void
     {
         $user = $this->createMock(User::class);
         $user->expects($this->once())
@@ -59,7 +60,7 @@ class TrainingPolicyTest extends TestCase
      *
      * @return void
      */
-    public function deleteTrainingPolicy(bool $expected): void
+    public function permissionDelete(bool $expected): void
     {
         $user = $this->createMock(User::class);
         $user->expects($this->once())
@@ -69,5 +70,31 @@ class TrainingPolicyTest extends TestCase
 
         $teamPolicy = new TrainingPolicy();
         $teamPolicy->delete($user);
+    }
+
+    /**
+     * A basic unit test view.
+     *
+     * @dataProvider permissionProvider
+     *
+     * @test
+     *
+     * @return void
+     */
+    public function permissionView(bool $expected): void
+    {
+        $userMock = $this->mock(User::class, function (MockInterface $mock) use ($expected) {
+            $mock->shouldReceive('hasPermissionTo')
+                ->with('edit-training')
+                ->andReturn($expected);
+
+            $mock->shouldReceive('hasPermissionTo')
+                ->with('view-training')
+                ->andReturn($expected);
+        });
+
+        $trainingPolicy = new TrainingPolicy();
+
+        $this->assertEquals($expected, $trainingPolicy->view($userMock));
     }
 }

--- a/tests/Unit/App/Policies/UserPolicyTest.php
+++ b/tests/Unit/App/Policies/UserPolicyTest.php
@@ -76,7 +76,7 @@ class UserPolicyTest extends TestCase
         $user = $this->createMock(User::class);
         $user->expects($this->once())
             ->method('hasPermissionTo')
-            ->with('delete-user')
+            ->with('edit-user')
             ->willReturn($expected);
 
         $userPolicy = new UserPolicy();

--- a/tests/Unit/App/Policies/UserPolicyTest.php
+++ b/tests/Unit/App/Policies/UserPolicyTest.php
@@ -22,7 +22,7 @@ class UserPolicyTest extends TestCase
         $user = $this->createMock(User::class);
         $user->expects($this->once())
             ->method('hasPermissionTo')
-            ->with('create-user')
+            ->with('edit-user')
             ->willReturn($expected);
 
         $userPolicy = new UserPolicy();

--- a/tests/Unit/App/Policies/UserPolicyTest.php
+++ b/tests/Unit/App/Policies/UserPolicyTest.php
@@ -4,8 +4,8 @@ namespace Tests\Unit\App\Policies;
 
 use App\Models\User;
 use App\Policies\UserPolicy;
-use Tests\TestCase;
 use Mockery\MockInterface;
+use Tests\TestCase;
 
 class UserPolicyTest extends TestCase
 {
@@ -106,7 +106,7 @@ class UserPolicyTest extends TestCase
         });
 
         $userPolicy = new UserPolicy();
-        
+
         $this->assertEquals($expected, $userPolicy->view($userMock));
     }
 }

--- a/tests/Unit/App/Policies/UserPolicyTest.php
+++ b/tests/Unit/App/Policies/UserPolicyTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\App\Policies;
 use App\Models\User;
 use App\Policies\UserPolicy;
 use Tests\TestCase;
+use Mockery\MockInterface;
 
 class UserPolicyTest extends TestCase
 {
@@ -17,7 +18,7 @@ class UserPolicyTest extends TestCase
      *
      * @return void
      */
-    public function create(bool $expected): void
+    public function permissionCreate(bool $expected): void
     {
         $user = $this->createMock(User::class);
         $user->expects($this->once())
@@ -50,7 +51,7 @@ class UserPolicyTest extends TestCase
      *
      * @return void
      */
-    public function edit(bool $expected): void
+    public function permissionEdit(bool $expected): void
     {
         $user = $this->createMock(User::class);
         $user->expects($this->once())
@@ -71,7 +72,7 @@ class UserPolicyTest extends TestCase
      *
      * @return void
      */
-    public function deleteUserPolicy(bool $expected): void
+    public function permissionDelete(bool $expected): void
     {
         $user = $this->createMock(User::class);
         $user->expects($this->once())
@@ -81,5 +82,31 @@ class UserPolicyTest extends TestCase
 
         $userPolicy = new UserPolicy();
         $userPolicy->delete($user);
+    }
+
+    /**
+     * A basic unit test view.
+     *
+     * @dataProvider permissionProvider
+     *
+     * @test
+     *
+     * @return void
+     */
+    public function permissionView(bool $expected): void
+    {
+        $userMock = $this->mock(User::class, function (MockInterface $mock) use ($expected) {
+            $mock->shouldReceive('hasPermissionTo')
+                ->with('edit-user')
+                ->andReturn($expected);
+
+            $mock->shouldReceive('hasPermissionTo')
+                ->with('view-user')
+                ->andReturn($expected);
+        });
+
+        $userPolicy = new UserPolicy();
+        
+        $this->assertEquals($expected, $userPolicy->view($userMock));
     }
 }


### PR DESCRIPTION
### O que?

* O principal objetivo da atividade seria fazer com que as permissões do sistema fossem tratadas de maneira que você pode editar (editar, cadastrar, fazer ações como de escrita) e visualizar (apenas ver) as informações no sistema. Assim limitando as ações do sistema a poder ter apenas 2 tipos de permissão. Isso foi devidamente aplicado em cada rota existente do sistema.
* As rotas de visualização de dados ainda não continham nível de permissão (apenas autenticação do usuário) para visualizar todas as informações de suas respectivas rotas de listagem e visualização individual dos itens.

### Por quê?

Tendo as permissões de um jeito mais amigavel, torna o sistema menos complexo e mais simples de se manter a longo prazo. (Também fica um pouco parecido com o jeito do Google de manter arquivos e informações em compartilhamento).

### Como?

* Refeito esquema de permissões dos usuários, e alterado todas as rotas de verificação de polices do sistema.
* Também foram criados testes funcionais específicos para verificar o correto funcionamento da aplicação dessas configurações de permissão no sistema.

