### PR TITLE
Confirmação de Treino: Criando end-point de listagem das confirmações do treino - VLC-48

### DIFF
--- a/app/GraphQL/Queries/ConfirmationTrainingQuery.php
+++ b/app/GraphQL/Queries/ConfirmationTrainingQuery.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\GraphQL\Queries;
+
+use App\Models\ConfirmationTraining;
+
+class ConfirmationTrainingQuery
+{
+    /**
+     * @codeCoverageIgnore
+     *
+     * @param  null  $_
+     * @param  array{}  $args
+     */
+    public function list($_, array $args)
+    {
+        $confirmationTraining = new ConfirmationTraining();
+
+        return $confirmationTraining->list($args);
+    }
+}

--- a/app/Models/ConfirmationTraining.php
+++ b/app/Models/ConfirmationTraining.php
@@ -45,6 +45,7 @@ class ConfirmationTraining extends Model
         if ($status === null) {
             return $query;
         }
+
         return $query->where('status', $status);
     }
 
@@ -53,6 +54,7 @@ class ConfirmationTraining extends Model
         if ($presenceId === null) {
             return $query;
         }
+
         return $query->where('presence', $presenceId);
     }
 
@@ -61,6 +63,7 @@ class ConfirmationTraining extends Model
         if ($playerId === null) {
             return $query;
         }
+
         return $query->where('player_id', $playerId);
     }
 
@@ -69,6 +72,7 @@ class ConfirmationTraining extends Model
         if ($teamId === null) {
             return $query;
         }
+
         return $query->where('team_id', $teamId);
     }
 
@@ -77,6 +81,7 @@ class ConfirmationTraining extends Model
         if ($trainingId === null) {
             return $query;
         }
+
         return $query->where('training_id', $trainingId);
     }
 
@@ -85,11 +90,12 @@ class ConfirmationTraining extends Model
         if ($userId === null) {
             return $query;
         }
+
         return $query->where('user_id', $userId);
     }
 
-    public function list(array $args) {
-
+    public function list(array $args)
+    {
         return $this->status($args['status'] ?? null)
             ->presence($args['presence'] ?? null)
             ->player($args['player_id'] ?? null)

--- a/app/Models/ConfirmationTraining.php
+++ b/app/Models/ConfirmationTraining.php
@@ -42,31 +42,60 @@ class ConfirmationTraining extends Model
 
     public function scopeStatus($query, $status)
     {
+        if ($status === null) {
+            return $query;
+        }
         return $query->where('status', $status);
     }
 
-    public function scopePresence($query, $presence)
+    public function scopePresence($query, $presenceId)
     {
-        return $query->where('presence', $presence);
+        if ($presenceId === null) {
+            return $query;
+        }
+        return $query->where('presence', $presenceId);
     }
 
-    public function scopePlayer($query, $player)
+    public function scopePlayer($query, $playerId)
     {
-        return $query->where('player_id', $player);
+        if ($playerId === null) {
+            return $query;
+        }
+        return $query->where('player_id', $playerId);
     }
 
-    public function scopeTeam($query, $team)
+    public function scopeTeam($query, $teamId)
     {
-        return $query->where('team_id', $team);
+        if ($teamId === null) {
+            return $query;
+        }
+        return $query->where('team_id', $teamId);
     }
 
-    public function scopeTraining($query, $training)
+    public function scopeTraining($query, $trainingId)
     {
-        return $query->where('training_id', $training);
+        if ($trainingId === null) {
+            return $query;
+        }
+        return $query->where('training_id', $trainingId);
     }
 
-    public function scopeUser($query, $user)
+    public function scopeUser($query, $userId)
     {
-        return $query->where('user_id', $user);
+        if ($userId === null) {
+            return $query;
+        }
+        return $query->where('user_id', $userId);
+    }
+
+    public function list(array $args) {
+
+        return $this->status($args['status'] ?? null)
+            ->presence($args['presence'] ?? null)
+            ->player($args['player_id'] ?? null)
+            ->team($args['team_id'] ?? null)
+            ->training($args['training_id'] ?? null)
+            ->user($args['user_id'] ?? null)
+            ->orderBy('created_at', 'desc');
     }
 }

--- a/app/Models/Training.php
+++ b/app/Models/Training.php
@@ -157,9 +157,9 @@ class Training extends Model
         $this->team->players()->each(function ($player) use ($daysNotification) {
             $confirmationTraining = $this->confirmationsTraining()->create([
                 'user_id' => auth()->user()->id ?? null,
-                'player_id' => $player->id ?? null,
-                'team_id' => $this->team_id ?? null,
-                'training_id' => $this->id ?? null,
+                'player_id' => $player->id,
+                'team_id' => $this->team_id,
+                'training_id' => $this->id,
                 'status' => 'pending',
                 'presence' => false,
             ]);

--- a/app/Policies/ConfirmationTrainingPolicy.php
+++ b/app/Policies/ConfirmationTrainingPolicy.php
@@ -9,7 +9,6 @@ class ConfirmationTrainingPolicy
 {
     use HandlesAuthorization;
 
-   
     /**
      * View a training instance.
      *

--- a/app/Policies/ConfirmationTrainingPolicy.php
+++ b/app/Policies/ConfirmationTrainingPolicy.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class ConfirmationTrainingPolicy
+{
+    use HandlesAuthorization;
+
+   
+    /**
+     * View a training instance.
+     *
+     * @param  User  $user
+     * @return bool
+     */
+    public function view(User $user): bool
+    {
+        return $user->hasPermissionTo('view-confirmation-training');
+    }
+}

--- a/database/migrations/tenant/base/2023_01_26_122248_create_confirmation_trainings_table.php
+++ b/database/migrations/tenant/base/2023_01_26_122248_create_confirmation_trainings_table.php
@@ -15,10 +15,10 @@ return new class extends Migration
     {
         Schema::create('confirmation_trainings', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('user_id')->constrained('users')->nullable();
-            $table->foreignId('player_id')->constrained('users')->nullable();
-            $table->foreignId('training_id')->constrained('trainings')->nullable();
-            $table->foreignId('team_id')->constrained('teams')->nullable();
+            $table->foreignId('user_id')->nullable()->constrained('users');
+            $table->foreignId('player_id')->constrained('users');
+            $table->foreignId('training_id')->constrained('trainings');
+            $table->foreignId('team_id')->constrained('teams');
             $table->enum('status', ['pending', 'confirmed', 'rejected'])->default('pending');
             $table->boolean('presence')->default(false);
 

--- a/database/seeders/tenants/PermissionTableSeeder.php
+++ b/database/seeders/tenants/PermissionTableSeeder.php
@@ -84,6 +84,11 @@ class PermissionTableSeeder extends Seeder
         $trainingConfig[] = Permission::updateOrCreate(['id' => 21], ['name' => 'view-training-config']);
 
         /**
+         * Permissões de Confirmação de Treino
+         */
+        $confirmationTraining[] = Permission::updateOrCreate(['id' => 22], ['name' => 'view-confirmation-training']);
+
+        /**
          * Relacionando Permissões
          */
         $this->sync($technician, $user);
@@ -93,6 +98,8 @@ class PermissionTableSeeder extends Seeder
         $this->sync($technician, $position);
         $this->sync($technician, $training);
         $this->sync($technician, $config);
+        $this->sync($technician, $trainingConfig);
+        $this->sync($technician, $confirmationTraining);
 
         $this->sync($admin, $user);
         $this->sync($admin, $team);
@@ -101,6 +108,8 @@ class PermissionTableSeeder extends Seeder
         $this->sync($admin, $position);
         $this->sync($admin, $training);
         $this->sync($admin, $config);
+        $this->sync($admin, $trainingConfig);
+        $this->sync($admin, $confirmationTraining);
 
         $this->sync($player, $user);
         $this->sync($player, $team);
@@ -109,6 +118,8 @@ class PermissionTableSeeder extends Seeder
         $this->sync($player, $position);
         $this->sync($player, $training);
         $this->sync($player, $config);
+        $this->sync($player, $trainingConfig);
+        $this->sync($player, $confirmationTraining);
 
         /**
          * Definir user como perfil de admin

--- a/graphql/confirmation-training/ConfirmationTrainingListType.graphql
+++ b/graphql/confirmation-training/ConfirmationTrainingListType.graphql
@@ -1,0 +1,40 @@
+"ConfirmationTrainings"
+type ConfirmationTrainingList {
+    "Unique primary key."
+    id: ID!
+
+    "UserId editing the confirmation training."
+    userId: Int @rename(attribute: "user_id")
+    
+    "User editing the fundamental."
+    user: User @belongsTo
+
+    "Player Id confirming training."
+    playerId: Int @rename(attribute: "player_id")
+
+    "Player confirming training."
+    player: User @belongsTo
+
+    "Training Id confirming training."
+    trainingId: Int @rename(attribute: "training_id")
+
+    "Training confirming training."
+    training: Training @belongsTo
+
+    "Confirmation status. One of `PENDING`, `CONFIRMED`, `REJECTED`."
+    status: String
+
+    "Team Id confirming training."
+    teamId: Int @rename(attribute: "team_id")
+
+    "Training confirming training."
+    team: Team @belongsTo
+
+    
+
+    "Date created. A datetime string with format `Y-m-d H:i:s`, e.g. `2018-05-23 13:43:32`."
+    createdAt: DateTime! @rename(attribute: "created_at")
+    
+    "Date updated. A datetime string with format `Y-m-d H:i:s`, e.g. `2018-05-23 13:43:32`."
+    updatedAt: DateTime! @rename(attribute: "updated_at")
+}

--- a/graphql/confirmation-training/ConfirmationTrainingListType.graphql
+++ b/graphql/confirmation-training/ConfirmationTrainingListType.graphql
@@ -30,7 +30,8 @@ type ConfirmationTrainingList {
     "Training confirming training."
     team: Team @belongsTo
 
-    
+    "Confirmation presence."
+    presence: Boolean
 
     "Date created. A datetime string with format `Y-m-d H:i:s`, e.g. `2018-05-23 13:43:32`."
     createdAt: DateTime! @rename(attribute: "created_at")

--- a/graphql/confirmation-training/ConfirmationTrainingMutation.graphql
+++ b/graphql/confirmation-training/ConfirmationTrainingMutation.graphql
@@ -9,9 +9,3 @@ extend type Mutation @guard {
         @field(resolver: "ConfirmationTrainingMutation@confirmTraining") 
         @validator
 }
-
-enum ConfirmationTrainingStatus {
-  PENDING @enum(value: pending)
-  CONFIRMED @enum(value: confirmed)
-  REJECTED @enum(value: rejected)
-}

--- a/graphql/confirmation-training/ConfirmationTrainingQuery.graphql
+++ b/graphql/confirmation-training/ConfirmationTrainingQuery.graphql
@@ -17,6 +17,9 @@ extend type Query @guard {
         "Filters by the training's status. One of `PENDING`, `CONFIRMED`, `REJECTED`."
         status: ConfirmationTrainingStatus
 
+        "Filters by the training's presence."
+        presence: Boolean
+
     ): [ConfirmationTrainingList!]! 
         @can(ability: "view", resolved: true)
         @paginate(

--- a/graphql/confirmation-training/ConfirmationTrainingQuery.graphql
+++ b/graphql/confirmation-training/ConfirmationTrainingQuery.graphql
@@ -1,0 +1,27 @@
+extend type Query @guard {
+    
+    "List of training confirmations"
+    confirmationsTraining(
+        "Filters by the training's user_id."
+        userId: Int @rename(attribute: "user_id")
+
+        "Filters by the training's player_id."
+        playerId: Int @rename(attribute: "player_id")
+
+        "Filters by the training's training_id."
+        trainingId: Int! @rename(attribute: "training_id")
+
+        "Filters by the training's team_id."
+        teamId: Int @rename(attribute: "team_id")
+
+        "Filters by the training's status. One of `PENDING`, `CONFIRMED`, `REJECTED`."
+        status: ConfirmationTrainingStatus
+
+    ): [ConfirmationTrainingList!]! 
+        @can(ability: "view", resolved: true)
+        @paginate(
+            builder: "App\\GraphQL\\Queries\\ConfirmationTrainingQuery@list"
+            defaultCount: 10, 
+            maxCount: 100
+        )
+}

--- a/graphql/confirmation-training/ConfirmationTrainingQuery.graphql
+++ b/graphql/confirmation-training/ConfirmationTrainingQuery.graphql
@@ -1,4 +1,4 @@
-extend type Query @guard {
+extend type Query {
     
     "List of training confirmations"
     confirmationsTraining(
@@ -20,7 +20,7 @@ extend type Query @guard {
         "Filters by the training's presence."
         presence: Boolean
 
-    ): [ConfirmationTrainingList!]! 
+    ): [ConfirmationTraining!]!
         @can(ability: "view", resolved: true)
         @paginate(
             builder: "App\\GraphQL\\Queries\\ConfirmationTrainingQuery@list"

--- a/graphql/confirmation-training/ConfirmationTrainingStatus.graphql
+++ b/graphql/confirmation-training/ConfirmationTrainingStatus.graphql
@@ -1,0 +1,5 @@
+enum ConfirmationTrainingStatus {
+  PENDING @enum(value: pending)
+  CONFIRMED @enum(value: confirmed)
+  REJECTED @enum(value: rejected)
+}

--- a/tests/Feature/GraphQL/ConfirmationTrainingTest.php
+++ b/tests/Feature/GraphQL/ConfirmationTrainingTest.php
@@ -62,7 +62,7 @@ class ConfirmationTrainingTest extends TestCase
         $response = $this->graphQL(
             'confirmationsTraining',
             [
-                'trainingId' => 1,
+                'trainingId' => $training->id,
                 'first' => 10,
                 'page' => 1,
             ],
@@ -80,7 +80,6 @@ class ConfirmationTrainingTest extends TestCase
             $hasPermission,
             $expectedMessage
         );
-
 
         if ($hasPermission) {
             $response

--- a/tests/Feature/GraphQL/ConfirmationTrainingTest.php
+++ b/tests/Feature/GraphQL/ConfirmationTrainingTest.php
@@ -27,6 +27,100 @@ class ConfirmationTrainingTest extends TestCase
         'updatedAt',
     ];
 
+    private function setPermissions(bool $hasPermission)
+    {
+        $this->checkPermission($hasPermission, $this->role, 'view-confirmation-training');
+    }
+
+    /**
+     * Listagem de todos os fundamentos.
+     *
+     * @author Maicon Cerutti
+     *
+     * @test
+     *
+     * @dataProvider listProvider
+     *
+     * @return void
+     */
+    public function confirmationsTrainingsList(
+        $typeMessageError,
+        $expectedMessage,
+        $expected,
+        bool $hasPermission
+    ) {
+        $this->setPermissions($hasPermission);
+
+        $team = Team::factory()
+            ->hasPlayers(10)
+            ->create();
+
+        $training = Training::factory()
+            ->setTeamId($team->id)
+            ->create();
+
+        $response = $this->graphQL(
+            'confirmationsTraining',
+            [
+                'trainingId' => 1,
+                'first' => 10,
+                'page' => 1,
+            ],
+            [
+                'paginatorInfo' => $this->paginatorInfo,
+                'data' => $this->data,
+            ],
+            'query',
+            false
+        );
+
+        $this->assertMessageError(
+            $typeMessageError,
+            $response,
+            $hasPermission,
+            $expectedMessage
+        );
+
+
+        if ($hasPermission) {
+            $response
+                ->assertJsonStructure($expected)
+                ->assertStatus(200);
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function listProvider()
+    {
+        return [
+            'with permission' => [
+                'type_message_error' => false,
+                'expected_message' => false,
+                'expected' => [
+                    'data' => [
+                        'confirmationsTraining' => [
+                            'paginatorInfo' => $this->paginatorInfo,
+                            'data' => [
+                                '*' => $this->data,
+                            ],
+                        ],
+                    ],
+                ],
+                'hasPermission' => true,
+            ],
+            'without permission' => [
+                'type_message_error' => 'message',
+                'expected_message' => $this->unauthorized,
+                'expected' => [
+                    'errors' => $this->errors,
+                ],
+                'hasPermission' => false,
+            ],
+        ];
+    }
+
     /**
      * Método de exclusão de um fundamento.
      *

--- a/tests/Feature/GraphQL/TrainingTest.php
+++ b/tests/Feature/GraphQL/TrainingTest.php
@@ -3,9 +3,9 @@
 namespace Tests\Feature\GraphQL;
 
 use App\Models\Team;
-use App\Models\User;
 use App\Models\TeamsUsers;
 use App\Models\Training;
+use App\Models\User;
 use Faker\Factory as Faker;
 use Tests\TestCase;
 
@@ -156,7 +156,7 @@ class TrainingTest extends TestCase
         bool $hasPermission
     ) {
         $this->be(User::find(3));
-        
+
         $this->setPermissions($hasPermission);
 
         $training = Training::factory()->make();

--- a/tests/Unit/App/Models/ConfirmationTrainingTest.php
+++ b/tests/Unit/App/Models/ConfirmationTrainingTest.php
@@ -65,83 +65,118 @@ class ConfirmationTrainingTest extends TestCase
      * A basic unit test relation scopeStatus.
      *
      * @test
+     * 
+     * @dataProvider scopeFilterProvider
      *
      * @return void
      */
-    public function scopeStatus()
+    public function scopeStatus($parameter)
     {
         $confirmationTraining = new ConfirmationTraining();
+        $class = $parameter === null ? ConfirmationTraining::class : Builder::class;
 
-        $this->assertInstanceOf(Builder::class, $confirmationTraining->scopeStatus($confirmationTraining, true));
+        $this->assertInstanceOf($class, $confirmationTraining->scopeStatus($confirmationTraining, $parameter));
     }
 
     /**
      * A basic unit test relation scopePresence.
      *
      * @test
+     * 
+     * @dataProvider scopeFilterProvider
      *
      * @return void
      */
-    public function scopePresence()
+    public function scopePresence($parameter)
     {
         $confirmationTraining = new ConfirmationTraining();
+        $class = $parameter === null ? ConfirmationTraining::class : Builder::class;
 
-        $this->assertInstanceOf(Builder::class, $confirmationTraining->scopePresence($confirmationTraining, true));
+        $this->assertInstanceOf($class, $confirmationTraining->scopePresence($confirmationTraining, $parameter));
     }
 
     /**
      * A basic unit test relation scopePlayer.
      *
      * @test
+     * 
+     * @dataProvider scopeFilterProvider
      *
      * @return void
      */
-    public function scopePlayer()
+    public function scopePlayer($parameter)
     {
         $confirmationTraining = new ConfirmationTraining();
+        $class = $parameter === null ? ConfirmationTraining::class : Builder::class;
 
-        $this->assertInstanceOf(Builder::class, $confirmationTraining->scopePlayer($confirmationTraining, true));
+        $this->assertInstanceOf($class, $confirmationTraining->scopePlayer($confirmationTraining, $parameter));
     }
 
     /**
      * A basic unit test relation scopeTeam.
      *
      * @test
+     * 
+     * @dataProvider scopeFilterProvider
      *
      * @return void
      */
-    public function scopeTeam()
+    public function scopeTeam($parameter)
     {
         $confirmationTraining = new ConfirmationTraining();
+        $class = $parameter === null ? ConfirmationTraining::class : Builder::class;
 
-        $this->assertInstanceOf(Builder::class, $confirmationTraining->scopeTeam($confirmationTraining, true));
+        $this->assertInstanceOf($class, $confirmationTraining->scopeTeam($confirmationTraining, $parameter));
     }
 
     /**
      * A basic unit test relation scopeTraining.
      *
      * @test
+     * 
+     * @dataProvider scopeFilterProvider
      *
      * @return void
      */
-    public function scopeTraining()
+    public function scopeTraining($parameter)
     {
         $confirmationTraining = new ConfirmationTraining();
+        $class = $parameter === null ? ConfirmationTraining::class : Builder::class;
 
-        $this->assertInstanceOf(Builder::class, $confirmationTraining->scopeTraining($confirmationTraining, true));
+        $this->assertInstanceOf($class, $confirmationTraining->scopeTraining($confirmationTraining, $parameter));
     }
 
     /**
      * A basic unit test relation scopeUser.
      *
      * @test
+     * 
+     * @dataProvider scopeFilterProvider
      *
      * @return void
      */
-    public function scopeUser()
+    public function scopeUser($parameter)
     {
         $confirmationTraining = new ConfirmationTraining();
+        $class = $parameter === null ? ConfirmationTraining::class : Builder::class;
 
-        $this->assertInstanceOf(Builder::class, $confirmationTraining->scopeUser($confirmationTraining, true));
+        $this->assertInstanceOf($class, $confirmationTraining->scopeUser($confirmationTraining, $parameter));
+    }
+
+    /**
+     * A dataProvider scopeFilterProvider.
+     *
+     * @return void
+     */
+    public function scopeFilterProvider()
+    {
+        return [
+            'parameter with value' => [
+                'parameter' => true,
+            ],
+            'parameter without value' => [
+                'parameter' => null,
+            ],
+        ];
     }
 }

--- a/tests/Unit/App/Models/ConfirmationTrainingTest.php
+++ b/tests/Unit/App/Models/ConfirmationTrainingTest.php
@@ -179,4 +179,52 @@ class ConfirmationTrainingTest extends TestCase
             ],
         ];
     }
+
+    /**
+     * A basic unit test method list.
+     *
+     * @test
+     * 
+     * @dataProvider listProvider
+     * 
+     * @return void
+     */
+
+    public function list($args)
+    {
+        $confirmationTraining = new ConfirmationTraining();
+
+        $this->assertInstanceOf(Builder::class, $confirmationTraining->list($args));
+    }
+
+    /**
+     * A dataProvider listProvider.
+     *
+     * @return void
+     */
+    public function listProvider()
+    {
+        return [
+            'parameter with value' => [
+                'args' => [
+                    'status' => 'confirmed',
+                    'presence' => false,
+                    'player_id' => 1,
+                    'user_id' => 1,
+                    'team_id' => 1,
+                    'training_id' => 1,
+                ],
+            ],
+            'parameter without value' => [
+                'args' => [
+                    'status' => null,
+                    'presence' => null,
+                    'player_id' => null,
+                    'user_id' => null,
+                    'team_id' => null,
+                    'training_id' => null,
+                ],
+            ],
+        ];
+    }
 }

--- a/tests/Unit/App/Models/ConfirmationTrainingTest.php
+++ b/tests/Unit/App/Models/ConfirmationTrainingTest.php
@@ -65,7 +65,7 @@ class ConfirmationTrainingTest extends TestCase
      * A basic unit test relation scopeStatus.
      *
      * @test
-     * 
+     *
      * @dataProvider scopeFilterProvider
      *
      * @return void
@@ -82,7 +82,7 @@ class ConfirmationTrainingTest extends TestCase
      * A basic unit test relation scopePresence.
      *
      * @test
-     * 
+     *
      * @dataProvider scopeFilterProvider
      *
      * @return void
@@ -99,7 +99,7 @@ class ConfirmationTrainingTest extends TestCase
      * A basic unit test relation scopePlayer.
      *
      * @test
-     * 
+     *
      * @dataProvider scopeFilterProvider
      *
      * @return void
@@ -116,7 +116,7 @@ class ConfirmationTrainingTest extends TestCase
      * A basic unit test relation scopeTeam.
      *
      * @test
-     * 
+     *
      * @dataProvider scopeFilterProvider
      *
      * @return void
@@ -133,7 +133,7 @@ class ConfirmationTrainingTest extends TestCase
      * A basic unit test relation scopeTraining.
      *
      * @test
-     * 
+     *
      * @dataProvider scopeFilterProvider
      *
      * @return void
@@ -150,7 +150,7 @@ class ConfirmationTrainingTest extends TestCase
      * A basic unit test relation scopeUser.
      *
      * @test
-     * 
+     *
      * @dataProvider scopeFilterProvider
      *
      * @return void
@@ -184,12 +184,11 @@ class ConfirmationTrainingTest extends TestCase
      * A basic unit test method list.
      *
      * @test
-     * 
+     *
      * @dataProvider listProvider
-     * 
+     *
      * @return void
      */
-
     public function list($args)
     {
         $confirmationTraining = new ConfirmationTraining();

--- a/tests/Unit/App/Policies/ConfirmationTrainingPolicyTest.php
+++ b/tests/Unit/App/Policies/ConfirmationTrainingPolicyTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Unit\App\Policies;
+
+use App\Models\User;
+use App\Policies\ConfirmationTrainingPolicy;
+use Mockery\MockInterface;
+use Tests\TestCase;
+
+class ConfirmationTrainingPolicyTest extends TestCase
+{
+    /**
+     * A basic unit test view.
+     *
+     * @dataProvider permissionProvider
+     *
+     * @test
+     *
+     * @return void
+     */
+    public function permissionView(bool $expected): void
+    {
+        $userMock = $this->mock(User::class, function (MockInterface $mock) use ($expected) {
+
+            $mock->shouldReceive('hasPermissionTo')
+                ->with('view-confirmation-training')
+                ->andReturn($expected);
+        });
+
+        $confirmationTrainingPolicy = new ConfirmationTrainingPolicy();
+
+        $this->assertEquals($expected, $confirmationTrainingPolicy->view($userMock));
+    }
+}

--- a/tests/Unit/App/Policies/ConfirmationTrainingPolicyTest.php
+++ b/tests/Unit/App/Policies/ConfirmationTrainingPolicyTest.php
@@ -21,7 +21,6 @@ class ConfirmationTrainingPolicyTest extends TestCase
     public function permissionView(bool $expected): void
     {
         $userMock = $this->mock(User::class, function (MockInterface $mock) use ($expected) {
-
             $mock->shouldReceive('hasPermissionTo')
                 ->with('view-confirmation-training')
                 ->andReturn($expected);

--- a/tests/Unit/App/Policies/TrainingPolicyTest.php
+++ b/tests/Unit/App/Policies/TrainingPolicyTest.php
@@ -26,8 +26,8 @@ class TrainingPolicyTest extends TestCase
             ->with('edit-training')
             ->willReturn($expected);
 
-        $teamPolicy = new TrainingPolicy();
-        $teamPolicy->create($user);
+        $trainingPolicy = new TrainingPolicy();
+        $trainingPolicy->create($user);
     }
 
     /**
@@ -47,8 +47,8 @@ class TrainingPolicyTest extends TestCase
             ->with('edit-training')
             ->willReturn($expected);
 
-        $teamPolicy = new TrainingPolicy();
-        $teamPolicy->edit($user);
+        $trainingPolicy = new TrainingPolicy();
+        $trainingPolicy->edit($user);
     }
 
     /**
@@ -68,8 +68,8 @@ class TrainingPolicyTest extends TestCase
             ->with('edit-training')
             ->willReturn($expected);
 
-        $teamPolicy = new TrainingPolicy();
-        $teamPolicy->delete($user);
+        $trainingPolicy = new TrainingPolicy();
+        $trainingPolicy->delete($user);
     }
 
     /**


### PR DESCRIPTION
### O que?

Criado rota para listagem dos registros de confirmação de treino dos usuários.

### Por quê?

Para um treino acontecer, o técnico deve ter visão dos jogadores que confirmaram o treino.

### Como?

Criado rota que disponibiliza essa informação com base no id do treino. Juntamente com alguns filtros básicos, com as informações da própria tabela.
