### PR TITLE
Notificações por E-mail: Ajustado notificações de treino, lógica incorreta para envio de e-mails - VLC 57

### DIFF
--- a/app/Mail/Training/ConfirmationNotificationTrainingMail.php
+++ b/app/Mail/Training/ConfirmationNotificationTrainingMail.php
@@ -24,8 +24,10 @@ class ConfirmationNotificationTrainingMail extends Mail
     public function __construct(Training $training, User $user)
     {
         parent::__construct($training, $user);
-        $this->title = "$training->name - {$training->date_start->format('d/m/Y')} das " .
-            "{$training->date_start->format('H:m')} ás {$training->date_end->format('H:m')}";
+        $this->title = "$training->name - {$training->date_start->format('d/m/Y')} " . 
+            trans('TrainingNotification.preposition_hours_from') . " " .
+            "{$training->date_start->format('H:m')} " . trans('TrainingNotification.preposition_hours_to') .
+            " {$training->date_end->format('H:m')}";
     }
 
     /**
@@ -38,7 +40,8 @@ class ConfirmationNotificationTrainingMail extends Mail
         return new Envelope(
             subject: env('APP_NAME') .
             ' - ' . trans('TrainingNotification.title_mail_confirmation') .
-            ' - ' . $this->training->date_start->format('d/m/Y H:m') .
+            ' - ' . $this->training->date_start->format('d/m/Y H:m') . 
+            ' ' . trans('TrainingNotification.preposition_hours_to') . ' ' .
             $this->training->date_end->format('H:m')
         );
     }

--- a/app/Mail/Training/ConfirmationNotificationTrainingMail.php
+++ b/app/Mail/Training/ConfirmationNotificationTrainingMail.php
@@ -24,8 +24,8 @@ class ConfirmationNotificationTrainingMail extends Mail
     public function __construct(Training $training, User $user)
     {
         parent::__construct($training, $user);
-        $this->title = "$training->name - {$training->date_start->format('d/m/Y')} " . 
-            trans('TrainingNotification.preposition_hours_from') . " " .
+        $this->title = "$training->name - {$training->date_start->format('d/m/Y')} " .
+            trans('TrainingNotification.preposition_hours_from') . ' ' .
             "{$training->date_start->format('H:m')} " . trans('TrainingNotification.preposition_hours_to') .
             " {$training->date_end->format('H:m')}";
     }
@@ -40,7 +40,7 @@ class ConfirmationNotificationTrainingMail extends Mail
         return new Envelope(
             subject: env('APP_NAME') .
             ' - ' . trans('TrainingNotification.title_mail_confirmation') .
-            ' - ' . $this->training->date_start->format('d/m/Y H:m') . 
+            ' - ' . $this->training->date_start->format('d/m/Y H:m') .
             ' ' . trans('TrainingNotification.preposition_hours_to') . ' ' .
             $this->training->date_end->format('H:m')
         );

--- a/app/Mail/Training/NotificationTrainingMail.php
+++ b/app/Mail/Training/NotificationTrainingMail.php
@@ -24,8 +24,10 @@ class NotificationTrainingMail extends Mail
     public function __construct(Training $training, User $user)
     {
         parent::__construct($training, $user);
-        $this->title = "{$training->name} - {$training->date_start->format('d/m/Y')} das " .
-            "{$training->date_start->format('H:m')} ás {$training->date_end->format('H:m')}";
+        $this->title = "{$training->name} - {$training->date_start->format('d/m/Y')} " .
+            trans('TrainingNotification.preposition_hours_from') .
+            " {$training->date_start->format('H:m')} " . trans('TrainingNotification.preposition_hours_to') . 
+            " {$training->date_end->format('H:m')}";
     }
 
     /**
@@ -39,6 +41,7 @@ class NotificationTrainingMail extends Mail
             subject: env('APP_NAME') .
             ' - ' . trans('TrainingNotification.title_mail') .
             ' - ' . $this->training->date_start->format('d/m/Y H:m') .
+            ' ' . trans('TrainingNotification.preposition_hours_to') . ' ' .
             $this->training->date_end->format('H:m')
         );
     }

--- a/app/Mail/Training/NotificationTrainingMail.php
+++ b/app/Mail/Training/NotificationTrainingMail.php
@@ -26,7 +26,7 @@ class NotificationTrainingMail extends Mail
         parent::__construct($training, $user);
         $this->title = "{$training->name} - {$training->date_start->format('d/m/Y')} " .
             trans('TrainingNotification.preposition_hours_from') .
-            " {$training->date_start->format('H:m')} " . trans('TrainingNotification.preposition_hours_to') . 
+            " {$training->date_start->format('H:m')} " . trans('TrainingNotification.preposition_hours_to') .
             " {$training->date_end->format('H:m')}";
     }
 

--- a/app/Models/Training.php
+++ b/app/Models/Training.php
@@ -151,7 +151,7 @@ class Training extends Model
      * @param  int|null|null  $daysNotification
      * @return void
      */
-    public function createConfirmationsPlayers( $daysNotification = null)
+    public function createConfirmationsPlayers($daysNotification = null)
     {
         $daysNotification = $daysNotification ?? TrainingConfig::first()->days_notification;
         $this->team->players()->each(function ($player) use ($daysNotification) {

--- a/app/Models/Training.php
+++ b/app/Models/Training.php
@@ -151,7 +151,7 @@ class Training extends Model
      * @param  int|null|null  $daysNotification
      * @return void
      */
-    public function createConfirmationsPlayers(int|null $daysNotification = null)
+    public function createConfirmationsPlayers( $daysNotification = null)
     {
         $daysNotification = $daysNotification ?? TrainingConfig::first()->days_notification;
         $this->team->players()->each(function ($player) use ($daysNotification) {

--- a/app/Notifications/Training/Notification.php
+++ b/app/Notifications/Training/Notification.php
@@ -57,8 +57,7 @@ class Notification extends IlluminateNotification implements ShouldQueue
             : $notificationTeamByEmail;
 
         if (
-            ($notifiable->hasRoleTechnician() && $notificationTechnicianByEmail) ||
-            ($notifiable->hasRolePlayer() && $notificationTeamByEmail)
+            $notificationTechnicianByEmail || $notificationTeamByEmail
         ) {
             return ['database', 'mail'];
         }

--- a/lang/en/TrainingNotification.php
+++ b/lang/en/TrainingNotification.php
@@ -13,8 +13,8 @@ return [
     |
     */
 
-    'title_mail' => 'Notificação de Treino',
-    'title_mail_confirmation' => 'Confirmação de Notificações de Treino',
-    'preposition_hours_from' => 'até',
-    'preposition_hours_to' => 'ás',
+    'title_mail' => 'Training Notification',
+    'title_mail_confirmation' => 'Training Notification Confirmation',
+    'preposition_hours_from' => 'from',
+    'preposition_hours_to' => 'to',
 ];


### PR DESCRIPTION
### O que?

A lógica para envio de e-mails através da fila de envio de e-mail estava incorreta, esperava que tivesse um usuário logado para ação (o que não deve haver para uma fila).

### Por quê?

E-mails de notificação de treino para os jogadores não estava funcionando. Não enviava o e-mail.