### PR TITLE
Treino: Adicionando ações de cancelamento de Treino - VLC-55 - VLC-56

### DIFF
--- a/app/GraphQL/Validators/Mutation/ConfirmPresenceValidator.php
+++ b/app/GraphQL/Validators/Mutation/ConfirmPresenceValidator.php
@@ -3,6 +3,7 @@
 namespace App\GraphQL\Validators\Mutation;
 
 use App\Rules\CheckPlayerIsInTraining;
+use App\Rules\CheckTrainingCancelled;
 use Nuwave\Lighthouse\Validation\Validator;
 
 final class ConfirmPresenceValidator extends Validator
@@ -27,6 +28,8 @@ final class ConfirmPresenceValidator extends Validator
             ],
             'trainingId' => [
                 'required',
+                'exists:trainings,id',
+                new CheckTrainingCancelled($trainingId),
             ],
             'presence' => [
                 'required',

--- a/app/GraphQL/Validators/Mutation/ConfirmTrainingValidator.php
+++ b/app/GraphQL/Validators/Mutation/ConfirmTrainingValidator.php
@@ -3,6 +3,7 @@
 namespace App\GraphQL\Validators\Mutation;
 
 use App\Rules\CheckPlayerIsInTraining;
+use App\Rules\CheckTrainingCancelled;
 use Nuwave\Lighthouse\Validation\Validator;
 
 final class ConfirmTrainingValidator extends Validator
@@ -27,6 +28,8 @@ final class ConfirmTrainingValidator extends Validator
             ],
             'trainingId' => [
                 'required',
+                'exists:trainings,id',
+                new CheckTrainingCancelled($trainingId),
             ],
             'status' => [
                 'required',
@@ -42,7 +45,9 @@ final class ConfirmTrainingValidator extends Validator
         return [
             'playerId.required' => trans('ConfirmTraining.playerId_required'),
             'trainingId.required' => trans('ConfirmTraining.trainingId_required'),
+            'trainingId.exists' => trans('ConfirmTraining.trainingId_exists'),
             'status.required' => trans('ConfirmTraining.status_required'),
+            
         ];
     }
 }

--- a/app/GraphQL/Validators/Mutation/ConfirmTrainingValidator.php
+++ b/app/GraphQL/Validators/Mutation/ConfirmTrainingValidator.php
@@ -47,7 +47,7 @@ final class ConfirmTrainingValidator extends Validator
             'trainingId.required' => trans('ConfirmTraining.trainingId_required'),
             'trainingId.exists' => trans('ConfirmTraining.trainingId_exists'),
             'status.required' => trans('ConfirmTraining.status_required'),
-            
+
         ];
     }
 }

--- a/app/Mail/Training/CancelNotificationTrainingMail.php
+++ b/app/Mail/Training/CancelNotificationTrainingMail.php
@@ -42,7 +42,7 @@ class CancelNotificationTrainingMail extends Mail
             ' - ' . trans('TrainingNotification.title_mail_confirmation') .
             ' - ' . $this->training->date_start->format('d/m/Y H:m') .
             ' ' . trans('TrainingNotification.preposition_hours_to') . ' ' .
-            $this->training->date_end->format('H:m') . " - " . trans('TrainingNotification.cancel')
+            $this->training->date_end->format('H:m') . ' - ' . trans('TrainingNotification.cancel')
         );
     }
 

--- a/app/Mail/Training/CancelNotificationTrainingMail.php
+++ b/app/Mail/Training/CancelNotificationTrainingMail.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Mail\Training;
+
+use App\Models\Training;
+use App\Models\User;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+
+class CancelNotificationTrainingMail extends Mail
+{
+    /**
+     * The title of the mail.
+     *
+     * @var string
+     */
+    public $title;
+
+    /**
+     * Create a new message instance.
+     *
+     * @return void
+     */
+    public function __construct(Training $training, User $user)
+    {
+        parent::__construct($training, $user);
+        $this->title = "$training->name - {$training->date_start->format('d/m/Y')} " .
+            trans('TrainingNotification.preposition_hours_from') . ' ' .
+            "{$training->date_start->format('H:m')} " . trans('TrainingNotification.preposition_hours_to') .
+            " {$training->date_end->format('H:m')} - " . trans('TrainingNotification.cancel');
+    }
+
+    /**
+     * Get the message envelope.
+     *
+     * @return \Illuminate\Mail\Mailables\Envelope
+     */
+    public function envelope()
+    {
+        return new Envelope(
+            subject: env('APP_NAME') .
+            ' - ' . trans('TrainingNotification.title_mail_confirmation') .
+            ' - ' . $this->training->date_start->format('d/m/Y H:m') .
+            ' ' . trans('TrainingNotification.preposition_hours_to') . ' ' .
+            $this->training->date_end->format('H:m') . " - " . trans('TrainingNotification.cancel')
+        );
+    }
+
+    /**
+     * Get the message content definition.
+     *
+     * @return \Illuminate\Mail\Mailables\Content
+     */
+    public function content()
+    {
+        return new Content(
+            markdown: 'emails.training.cancellation-notification',
+        );
+    }
+}

--- a/app/Mail/Training/CancellationNotificationTrainingMail.php
+++ b/app/Mail/Training/CancellationNotificationTrainingMail.php
@@ -7,7 +7,7 @@ use App\Models\User;
 use Illuminate\Mail\Mailables\Content;
 use Illuminate\Mail\Mailables\Envelope;
 
-class CancelNotificationTrainingMail extends Mail
+class CancellationNotificationTrainingMail extends Mail
 {
     /**
      * The title of the mail.

--- a/app/Models/Training.php
+++ b/app/Models/Training.php
@@ -181,7 +181,7 @@ class Training extends Model
 
     /**
      * @codeCoverageIgnore
-     * 
+     *
      * @return void
      */
     public function sendNotificationPlayersTrainingCancelled()

--- a/app/Models/Training.php
+++ b/app/Models/Training.php
@@ -179,6 +179,11 @@ class Training extends Model
         $this->sendNotificationTechnicians($daysNotification);
     }
 
+    /**
+     * @codeCoverageIgnore
+     * 
+     * @return void
+     */
     public function sendNotificationPlayersTrainingCancelled()
     {
         $this->team->players()->each(function ($player) {

--- a/app/Models/Training.php
+++ b/app/Models/Training.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Notifications\Training\NotificationConfirmationTrainingNotification;
 use App\Notifications\Training\TrainingNotification;
+use App\Notifications\Training\NotificationCancelTrainingNotification;
 use App\Rules\RelationshipSpecificFundamental;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -176,5 +177,12 @@ class Training extends Model
         });
 
         $this->sendNotificationTechnicians($daysNotification);
+    }
+
+    public function sendNotificationPlayersTrainingCancelled()
+    {
+        $this->team->players()->each(function ($player) {
+            $player->notify(new NotificationCancelTrainingNotification($this, null));
+        });
     }
 }

--- a/app/Models/Training.php
+++ b/app/Models/Training.php
@@ -2,9 +2,9 @@
 
 namespace App\Models;
 
+use App\Notifications\Training\NotificationCancelTrainingNotification;
 use App\Notifications\Training\NotificationConfirmationTrainingNotification;
 use App\Notifications\Training\TrainingNotification;
-use App\Notifications\Training\NotificationCancelTrainingNotification;
 use App\Rules\RelationshipSpecificFundamental;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\HasFactory;

--- a/app/Notifications/Training/NotificationCancelTrainingNotification.php
+++ b/app/Notifications/Training/NotificationCancelTrainingNotification.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Notifications\Training;
+
+use App\Mail\Training\CancelNotificationTrainingMail;
+use App\Models\User;
+
+class NotificationCancelTrainingNotification extends Notification
+{
+    /**
+     * Get the mail representation of the notification.
+     *
+     * @codeCoverageIgnore
+     *
+     * @param  mixed  $notifiable
+     * @return \App\Mail\Training\CancelNotificationTrainingMail
+     */
+    public function toMail(User $notifiable)
+    {
+        return (new CancelNotificationTrainingMail($this->training, $notifiable))
+            ->to($notifiable->email);
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @codeCoverageIgnore
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function toArray(User $notifiable)
+    {
+        $this->training->team->players;
+
+        return [
+            'training' => $this->training,
+            'message' => trans('TrainingNotification.title_mail_cancel'),
+        ];
+    }
+}

--- a/app/Notifications/Training/NotificationCancelTrainingNotification.php
+++ b/app/Notifications/Training/NotificationCancelTrainingNotification.php
@@ -2,7 +2,7 @@
 
 namespace App\Notifications\Training;
 
-use App\Mail\Training\CancelNotificationTrainingMail;
+use App\Mail\Training\CancellationNotificationTrainingMail;
 use App\Models\User;
 
 class NotificationCancelTrainingNotification extends Notification
@@ -13,11 +13,11 @@ class NotificationCancelTrainingNotification extends Notification
      * @codeCoverageIgnore
      *
      * @param  mixed  $notifiable
-     * @return \App\Mail\Training\CancelNotificationTrainingMail
+     * @return \App\Mail\Training\CancellationNotificationTrainingMail
      */
     public function toMail(User $notifiable)
     {
-        return (new CancelNotificationTrainingMail($this->training, $notifiable))
+        return (new CancellationNotificationTrainingMail($this->training, $notifiable))
             ->to($notifiable->email);
     }
 

--- a/app/Observers/TrainingObserver.php
+++ b/app/Observers/TrainingObserver.php
@@ -34,10 +34,8 @@ class TrainingObserver
     {
         $training->createConfirmationsPlayers();
 
-        if ($training->getOriginal('status')) {
-            if ($training->status == 0) {
-                $training->sendNotificationPlayersTrainingCancelled();
-            }
+        if ($training->getOriginal('status') && $training->status == 0) {
+            $training->sendNotificationPlayersTrainingCancelled();
         }
     }
 }

--- a/app/Observers/TrainingObserver.php
+++ b/app/Observers/TrainingObserver.php
@@ -19,7 +19,6 @@ class TrainingObserver
     public function created(Training $training)
     {
         $training->createConfirmationsPlayers();
-        //Subscription::broadcast('notification', $training);
     }
 
     /**
@@ -34,7 +33,6 @@ class TrainingObserver
     public function updated(Training $training)
     {
         $training->createConfirmationsPlayers();
-        //Subscription::broadcast('notification', $training);
 
         if ($training->getOriginal('status')) {
             if ($training->status == 0) {

--- a/app/Observers/TrainingObserver.php
+++ b/app/Observers/TrainingObserver.php
@@ -26,6 +26,9 @@ class TrainingObserver
      * @param  Training  $training
      *
      * NOTE - Ignorado nos testes unitários por ser um método que envia notificação
+     * 
+     * @codeCoverageIgnore
+     * 
      * @return void
      */
     public function updated(Training $training)
@@ -33,7 +36,6 @@ class TrainingObserver
         $training->createConfirmationsPlayers();
         //Subscription::broadcast('notification', $training);
 
-        //dd($training->getOriginal('status'), $training->status);
         if ($training->getOriginal('status')) {
             if ($training->status == 0) {
                 $training->sendNotificationPlayersTrainingCancelled();

--- a/app/Observers/TrainingObserver.php
+++ b/app/Observers/TrainingObserver.php
@@ -27,7 +27,7 @@ class TrainingObserver
      *
      * NOTE - Ignorado nos testes unitários por ser um método que envia notificação
      *
-     * @codeCoverageIgnore
+     * 
      *
      * @return void
      */
@@ -36,7 +36,8 @@ class TrainingObserver
         $training->createConfirmationsPlayers();
         #Subscription::broadcast('notification', $training);
 
-        if ($training->isDirty('status')) {
+        //dd($training->getOriginal('status'), $training->status);
+        if ($training->getOriginal('status')) {
             if ($training->status == 0) {
                 $training->sendNotificationPlayersTrainingCancelled();
             }

--- a/app/Observers/TrainingObserver.php
+++ b/app/Observers/TrainingObserver.php
@@ -26,9 +26,9 @@ class TrainingObserver
      * @param  Training  $training
      *
      * NOTE - Ignorado nos testes unitários por ser um método que envia notificação
-     * 
+     *
      * @codeCoverageIgnore
-     * 
+     *
      * @return void
      */
     public function updated(Training $training)

--- a/app/Observers/TrainingObserver.php
+++ b/app/Observers/TrainingObserver.php
@@ -19,22 +19,19 @@ class TrainingObserver
     public function created(Training $training)
     {
         $training->createConfirmationsPlayers();
-        #Subscription::broadcast('notification', $training);
+        //Subscription::broadcast('notification', $training);
     }
 
     /**
      * @param  Training  $training
      *
      * NOTE - Ignorado nos testes unitários por ser um método que envia notificação
-     *
-     * 
-     *
      * @return void
      */
     public function updated(Training $training)
     {
         $training->createConfirmationsPlayers();
-        #Subscription::broadcast('notification', $training);
+        //Subscription::broadcast('notification', $training);
 
         //dd($training->getOriginal('status'), $training->status);
         if ($training->getOriginal('status')) {

--- a/app/Observers/TrainingObserver.php
+++ b/app/Observers/TrainingObserver.php
@@ -3,7 +3,6 @@
 namespace App\Observers;
 
 use App\Models\Training;
-use Nuwave\Lighthouse\Execution\Utils\Subscription;
 
 class TrainingObserver
 {

--- a/app/Observers/TrainingObserver.php
+++ b/app/Observers/TrainingObserver.php
@@ -35,5 +35,11 @@ class TrainingObserver
     {
         $training->createConfirmationsPlayers();
         #Subscription::broadcast('notification', $training);
+
+        if ($training->isDirty('status')) {
+            if ($training->status == 0) {
+                $training->sendNotificationPlayersTrainingCancelled();
+            }
+        }
     }
 }

--- a/app/Observers/TrainingObserver.php
+++ b/app/Observers/TrainingObserver.php
@@ -19,7 +19,7 @@ class TrainingObserver
     public function created(Training $training)
     {
         $training->createConfirmationsPlayers();
-        Subscription::broadcast('notification', $training);
+        #Subscription::broadcast('notification', $training);
     }
 
     /**
@@ -34,6 +34,6 @@ class TrainingObserver
     public function updated(Training $training)
     {
         $training->createConfirmationsPlayers();
-        Subscription::broadcast('notification', $training);
+        #Subscription::broadcast('notification', $training);
     }
 }

--- a/app/Rules/CheckTrainingCancelled.php
+++ b/app/Rules/CheckTrainingCancelled.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Rules;
+
+use App\Models\Training;
+use Illuminate\Contracts\Validation\Rule;
+
+class CheckTrainingCancelled implements Rule
+{
+    private int|null $trainingId;
+
+    private Training|null $training;
+
+    /**
+     * Create a new rule instance.
+     *
+     * @return void
+     */
+    public function __construct(
+        int|null $trainingId,
+        Training|null $training = null
+    ) {
+        $this->trainingId = $trainingId;
+        $this->training = $training ?? new Training();
+    }
+
+    /**
+     * Checks if the player is related in training.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        $this->training = $this->training->find($this->trainingId);
+        dd($this->training, $this->trainingId);
+        return $this->training->status;
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return trans('CheckPlayerIsInTraining.message_error');
+    }
+}

--- a/app/Rules/CheckTrainingCancelled.php
+++ b/app/Rules/CheckTrainingCancelled.php
@@ -34,6 +34,7 @@ class CheckTrainingCancelled implements Rule
     public function passes($attribute, $value)
     {
         $this->training = $this->training->find($this->trainingId);
+
         return $this->training->status;
     }
 

--- a/app/Rules/CheckTrainingCancelled.php
+++ b/app/Rules/CheckTrainingCancelled.php
@@ -34,7 +34,6 @@ class CheckTrainingCancelled implements Rule
     public function passes($attribute, $value)
     {
         $this->training = $this->training->find($this->trainingId);
-        dd($this->training, $this->trainingId);
         return $this->training->status;
     }
 
@@ -45,6 +44,6 @@ class CheckTrainingCancelled implements Rule
      */
     public function message()
     {
-        return trans('CheckPlayerIsInTraining.message_error');
+        return trans('CheckTrainingCancelled.message_error');
     }
 }

--- a/database/factories/NotificationFactory.php
+++ b/database/factories/NotificationFactory.php
@@ -27,7 +27,7 @@ class NotificationFactory extends Factory
 
     public function setNotifiableId($notifiableId)
     {
-        return $this->state(function() use ($notifiableId) {
+        return $this->state(function () use ($notifiableId) {
             return [
                 'notifiable_id' => $notifiableId,
             ];

--- a/database/factories/TrainingFactory.php
+++ b/database/factories/TrainingFactory.php
@@ -28,6 +28,7 @@ class TrainingFactory extends Factory
             'name' => $this->faker->city . ' TRAINING',
             'user_id' => 1,
             'team_id' => 1,
+            'status' => true,
             'description' => $this->faker->text,
             'date_start' => $dateStart,
             'date_end' => $dateEnd,
@@ -36,9 +37,18 @@ class TrainingFactory extends Factory
 
     public function setTeamId(int $teamId)
     {
-        return $this->state(function (array $attributes) use ($teamId) {
+        return $this->state(function () use ($teamId) {
             return [
                 'team_id' => $teamId,
+            ];
+        });
+    }
+
+    public function setStatus(bool $status)
+    {
+        return $this->state(function () use ($status) {
+            return [
+                'status' => $status,
             ];
         });
     }

--- a/lang/en/CheckTrainingCancelled.php
+++ b/lang/en/CheckTrainingCancelled.php
@@ -13,9 +13,5 @@ return [
     |
     */
 
-    'playerId_required' => 'O campo playerId é obrigatório',
-    'trainingId_required' => 'O campo trainingId é obrigatório',
-    'trainingId_exists' => 'O campo trainingId precisa ser de um treino que existente',
-    'status_required' => 'O campo status é obrigatório',
-    'presence_required' => 'O campo presence é obrigatório',
+    'message_error' => 'This workout has been cancelled, unable to do this action.',
 ];

--- a/lang/en/ConfirmTraining.php
+++ b/lang/en/ConfirmTraining.php
@@ -15,6 +15,7 @@ return [
 
     'playerId_required' => 'The playerId is a required field',
     'trainingId_required' => 'The trainingId is a required field',
+    'trainingId_exists' => 'The trainingId field needs to be from an existing training',
     'status_required' => 'The status is a required field',
     'presence_required' => 'The presence is a required field',
 ];

--- a/lang/en/NotificationMail.php
+++ b/lang/en/NotificationMail.php
@@ -27,7 +27,7 @@ return [
     'list_of_training_players' => 'List of players notified for training',
     'message_default_cancellation' => 'We hope you are having a good day. ' .
         'Unfortunately, we would like to inform you that the scheduled training has been canceled. ' .
-        'We apologize for any inconvenience this may have caused and we would like' 
+        'We apologize for any inconvenience this may have caused and we would like'
         . ' to thank you for your understanding. ' .
         'If you have any questions or need more information, please contact your coach.',
     'good_cancellation' => 'We appreciate your participation and look forward to seeing you at our next events',

--- a/lang/en/NotificationMail.php
+++ b/lang/en/NotificationMail.php
@@ -27,7 +27,8 @@ return [
     'list_of_training_players' => 'List of players notified for training',
     'message_default_cancellation' => 'We hope you are having a good day. ' .
         'Unfortunately, we would like to inform you that the scheduled training has been canceled. ' .
-        'We apologize for any inconvenience this may have caused and we would like to thank you for your understanding. ' .
+        'We apologize for any inconvenience this may have caused and we would like' 
+        . ' to thank you for your understanding. ' .
         'If you have any questions or need more information, please contact your coach.',
     'good_cancellation' => 'We appreciate your participation and look forward to seeing you at our next events',
 ];

--- a/lang/en/NotificationMail.php
+++ b/lang/en/NotificationMail.php
@@ -25,9 +25,9 @@ return [
     'message_please' => 'Please confirm your presence or absence.',
     'description_training' => 'Training Description',
     'list_of_training_players' => 'List of players notified for training',
-    'message_default_cancellation' => "We hope you are having a good day. " .
-        "Unfortunately, we would like to inform you that the scheduled training has been canceled. " .
-        "We apologize for any inconvenience this may have caused and we would like to thank you for your understanding. " .
-        "If you have any questions or need more information, please contact your coach.",
-    'good_cancellation' => 'We appreciate your participation and look forward to seeing you at our next events'
+    'message_default_cancellation' => 'We hope you are having a good day. ' .
+        'Unfortunately, we would like to inform you that the scheduled training has been canceled. ' .
+        'We apologize for any inconvenience this may have caused and we would like to thank you for your understanding. ' .
+        'If you have any questions or need more information, please contact your coach.',
+    'good_cancellation' => 'We appreciate your participation and look forward to seeing you at our next events',
 ];

--- a/lang/en/NotificationMail.php
+++ b/lang/en/NotificationMail.php
@@ -1,0 +1,33 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Authentication Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used during authentication for various
+    | messages that we need to display to the user. You are free to modify
+    | these language lines according to your application's requirements.
+    |
+    */
+
+    'answer_call' => 'Answer Call',
+    'thanks' => 'Best regards',
+    'title' => 'Training Notification',
+    'title_cancel' => 'Training Cancellation Notification',
+    'title_confirmation' => 'Training Notification Confirmations',
+    'hello' => 'Hello',
+    'good_training' => 'Good training',
+    'message_default_technician' => 'You are receiving this email because you are marked as a technician.',
+    'message_default' => 'You are receiving this email because you are part of the team that was marked for training.',
+    'message_please' => 'Please confirm your presence or absence.',
+    'description_training' => 'Training Description',
+    'list_of_training_players' => 'List of players notified for training',
+    'message_default_cancellation' => "We hope you are having a good day. " .
+        "Unfortunately, we would like to inform you that the scheduled training has been canceled. " .
+        "We apologize for any inconvenience this may have caused and we would like to thank you for your understanding. " .
+        "If you have any questions or need more information, please contact your coach.",
+    'good_cancellation' => 'We appreciate your participation and look forward to seeing you at our next events'
+];

--- a/lang/en/TrainingNotification.php
+++ b/lang/en/TrainingNotification.php
@@ -15,6 +15,8 @@ return [
 
     'title_mail' => 'Training Notification',
     'title_mail_confirmation' => 'Training Notification Confirmation',
+    'title_mail_cancel' => 'Training Notification Confirmation',
     'preposition_hours_from' => 'from',
     'preposition_hours_to' => 'to',
+    'cancel' => 'CANCELLED',
 ];

--- a/lang/pt-br/CheckTrainingCancelled.php
+++ b/lang/pt-br/CheckTrainingCancelled.php
@@ -13,9 +13,5 @@ return [
     |
     */
 
-    'playerId_required' => 'O campo playerId é obrigatório',
-    'trainingId_required' => 'O campo trainingId é obrigatório',
-    'trainingId_exists' => 'O campo trainingId precisa ser de um treino que existente',
-    'status_required' => 'O campo status é obrigatório',
-    'presence_required' => 'O campo presence é obrigatório',
+    'message_error' => 'Este treino foi cancelado, não é possível fazer esta ação.',
 ];

--- a/lang/pt-br/NotificationMail.php
+++ b/lang/pt-br/NotificationMail.php
@@ -25,10 +25,10 @@ return [
     'message_please' => 'Por favor, confirme sua presença ou ausência.',
     'description_training' => 'Descrição do treino',
     'list_of_training_players' => 'Listagem de jogadores notificados para o treino',
-    'message_default_cancellation' => "Esperamos que esteja tendo um bom dia. " .
-        "Infelizmente, gostaríamos de informar que o treino previsto foi cancelado. " .
-        "Lamentamos qualquer inconveniente que isso possa ter causado e gostaríamos " .
-        "de agradecer sua compreensão. Caso tenha alguma dúvida ou precisão de mais " .
-        "informações, por favor, entre em contato com seu técnico.",
-    'good_cancellation' => 'Agradecemos a sua participação e esperamos vê-lo em nossos próximos eventos'
+    'message_default_cancellation' => 'Esperamos que esteja tendo um bom dia. ' .
+        'Infelizmente, gostaríamos de informar que o treino previsto foi cancelado. ' .
+        'Lamentamos qualquer inconveniente que isso possa ter causado e gostaríamos ' .
+        'de agradecer sua compreensão. Caso tenha alguma dúvida ou precisão de mais ' .
+        'informações, por favor, entre em contato com seu técnico.',
+    'good_cancellation' => 'Agradecemos a sua participação e esperamos vê-lo em nossos próximos eventos',
 ];

--- a/lang/pt-br/NotificationMail.php
+++ b/lang/pt-br/NotificationMail.php
@@ -16,6 +16,7 @@ return [
     'answer_call' => 'Responder Chamada',
     'thanks' => 'Atenciosamente',
     'title' => 'Notificação de Treino',
+    'title_cancel' => 'Notificação de Cancelamento de Treino',
     'title_confirmation' => 'Confirmações de Notificações de Treino',
     'hello' => 'Olá',
     'good_training' => 'Bom treino',
@@ -24,4 +25,10 @@ return [
     'message_please' => 'Por favor, confirme sua presença ou ausência.',
     'description_training' => 'Descrição do treino',
     'list_of_training_players' => 'Listagem de jogadores notificados para o treino',
+    'message_default_cancellation' => "Esperamos que esteja tendo um bom dia. " .
+        "Infelizmente, gostaríamos de informar que o treino previsto foi cancelado. " .
+        "Lamentamos qualquer inconveniente que isso possa ter causado e gostaríamos " .
+        "de agradecer sua compreensão. Caso tenha alguma dúvida ou precisão de mais " .
+        "informações, por favor, entre em contato com seu técnico.",
+    'good_cancellation' => 'Agradecemos a sua participação e esperamos vê-lo em nossos próximos eventos'
 ];

--- a/lang/pt-br/TrainingNotification.php
+++ b/lang/pt-br/TrainingNotification.php
@@ -15,6 +15,8 @@ return [
 
     'title_mail' => 'Notificação de Treino',
     'title_mail_confirmation' => 'Confirmação de Notificações de Treino',
+    'title_mail_cancel' => 'Training Cancellation Notification',
     'preposition_hours_from' => 'até',
     'preposition_hours_to' => 'ás',
+    'cancel' => 'CANCELADO',
 ];

--- a/resources/views/emails/training/cancellation-notification.blade.php
+++ b/resources/views/emails/training/cancellation-notification.blade.php
@@ -1,0 +1,24 @@
+<x-mail::message>
+
+# {{ trans('NotificationMail.title_cancel') }}
+
+{{ trans('NotificationMail.hello') }}, {{$user->name}}!
+
+## {{$title}}
+
+## {{ trans('NotificationMail.description_training') }}:
+{{ $training->description }}
+
+<br/>
+
+{{ trans('NotificationMail.message_default_cancellation') }}
+
+{{ trans('NotificationMail.message_default') }}
+
+{{ trans('NotificationMail.good_cancellation') }}!
+<br>
+<br>
+{{ trans('NotificationMail.thanks') }},
+<br>
+{{ config('app.name') }}
+</x-mail::message>

--- a/routes/web.php
+++ b/routes/web.php
@@ -43,5 +43,5 @@ Route::get('/test-cancellation-notification-training-mail', function () {
     $training = App\Models\Training::find(1);
     $user = App\Models\User::find(3);
 
-    return new App\Mail\Training\CancelNotificationTrainingMail($training, $user);
+    return new App\Mail\Training\CancellationNotificationTrainingMail($training, $user);
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -38,3 +38,10 @@ Route::get('/test-confirmation-notification-training-mail', function () {
 
     return new App\Mail\Training\ConfirmationNotificationTrainingMail($training, $user);
 });
+
+Route::get('/test-cancellation-notification-training-mail', function () {
+    $training = App\Models\Training::find(1);
+    $user = App\Models\User::find(3);
+
+    return new App\Mail\Training\CancelNotificationTrainingMail($training, $user);
+});

--- a/tests/Feature/GraphQL/ConfirmationTrainingTest.php
+++ b/tests/Feature/GraphQL/ConfirmationTrainingTest.php
@@ -147,7 +147,7 @@ class ConfirmationTrainingTest extends TestCase
 
         $training = Training::factory()
             ->setTeamId($team->id)
-            ->setStatus(!$trainingCancelled)
+            ->setStatus(! $trainingCancelled)
             ->create();
 
         $confirmationTraining = $training->confirmationsTraining->first();
@@ -161,8 +161,8 @@ class ConfirmationTrainingTest extends TestCase
             ];
         } else {
             $parameters = $data['data_error'];
-            if(isset($data['data_error']['trainingId'])) {
-                if($data['data_error']['trainingId'] == 'find') {
+            if (isset($data['data_error']['trainingId'])) {
+                if ($data['data_error']['trainingId'] == 'find') {
                     $parameters['trainingId'] = $training->id;
                 }
             }
@@ -327,12 +327,12 @@ class ConfirmationTrainingTest extends TestCase
 
         $training = Training::factory()
             ->setTeamId($team->id)
-            ->setStatus(!$trainingCancelled)
+            ->setStatus(! $trainingCancelled)
             ->create();
 
         $confirmationTraining = $training->confirmationsTraining->first();
 
-        if($data['error'] !== true) {
+        if ($data['error'] !== true) {
             $parameters = [
                 'id' => $confirmationTraining->id,
                 'trainingId' => $confirmationTraining->training_id,
@@ -342,11 +342,10 @@ class ConfirmationTrainingTest extends TestCase
                     'value' => 'CONFIRMED',
                 ],
             ];
-        }
-        else {
+        } else {
             $parameters = $data['data_error'];
-            if(isset($data['data_error']['trainingId'])) {
-                if($data['data_error']['trainingId'] == 'find') {
+            if (isset($data['data_error']['trainingId'])) {
+                if ($data['data_error']['trainingId'] == 'find') {
                     $parameters['trainingId'] = $training->id;
                 }
             }

--- a/tests/Feature/GraphQL/ConfirmationTrainingTest.php
+++ b/tests/Feature/GraphQL/ConfirmationTrainingTest.php
@@ -300,8 +300,9 @@ class ConfirmationTrainingTest extends TestCase
             ->setStatus(!$trainingCancelled)
             ->create();
 
-        if ($data['error'] === null) {
-            $confirmationTraining = $training->confirmationsTraining->first();
+        $confirmationTraining = $training->confirmationsTraining->first();
+
+        if($data['error'] !== true) {
             $parameters = [
                 'id' => $confirmationTraining->id,
                 'trainingId' => $confirmationTraining->training_id,
@@ -311,8 +312,14 @@ class ConfirmationTrainingTest extends TestCase
                     'value' => 'CONFIRMED',
                 ],
             ];
-        } else {
+        }
+        else {
             $parameters = $data['data_error'];
+            if(isset($data['data_error']['trainingId'])) {
+                if($data['data_error']['trainingId'] == 'find') {
+                    $parameters['trainingId'] = $training->id;
+                }
+            }
         }
 
         $response = $this->graphQL(
@@ -346,6 +353,7 @@ class ConfirmationTrainingTest extends TestCase
             'confirm training, success' => [
                 [
                     'error' => null,
+                    'data_error' => null,
                 ],
                 'type_message_error' => false,
                 'expected_message' => false,
@@ -357,12 +365,10 @@ class ConfirmationTrainingTest extends TestCase
                 'hasPermission' => true,
                 'trainingCancelled' => false,
             ],
-            'training confirmation for player not part of training, expected error' => [
+            'training confirmation for player nott part of training, expected error' => [
                 [
                     'error' => true,
                     'data_error' => [
-                        'id' => 9999,
-                        'trainingId' => 9999,
                         'playerId' => 9999,
                         'status' => [
                             'type' => 'ENUM',
@@ -384,7 +390,7 @@ class ConfirmationTrainingTest extends TestCase
                     'error' => true,
                     'data_error' => [
                         'id' => 9999,
-                        'trainingId' => 9999,
+                        'trainingId' => 'find',
                         'status' => [
                             'type' => 'ENUM',
                             'value' => 'CONFIRMED',
@@ -425,9 +431,7 @@ class ConfirmationTrainingTest extends TestCase
                 [
                     'error' => true,
                     'data_error' => [
-                        'id' => 9999,
-                        'playerId' => 9999,
-                        'trainingId' => 9999,
+                        'trainingId' => 'find',
                     ],
                 ],
                 'type_message_error' => 'status',
@@ -443,17 +447,11 @@ class ConfirmationTrainingTest extends TestCase
                 [
                     'error' => true,
                     'data_error' => [
-                        // TODO - Colocar aqui um objeto cadastrado para fazer o teste correto e fazer a nova validação
-                        'id' => 9999,
-                        'playerId' => 9999,
-                        'status' => [
-                            'type' => 'ENUM',
-                            'value' => 'CONFIRMED',
-                        ],
+                        'trainingId' => 'find',
                     ],
                 ],
                 'type_message_error' => 'trainingId',
-                'expected_message' => 'CheckPlayerIsInTraining.trainingId_required',
+                'expected_message' => 'CheckTrainingCancelled.message_error',
                 'expected' => [
                     'errors' => $this->errors,
                     'data' => $confirmationTraining,

--- a/tests/Feature/GraphQL/ConfirmationTrainingTest.php
+++ b/tests/Feature/GraphQL/ConfirmationTrainingTest.php
@@ -161,10 +161,11 @@ class ConfirmationTrainingTest extends TestCase
             ];
         } else {
             $parameters = $data['data_error'];
-            if (isset($data['data_error']['trainingId'])) {
-                if ($data['data_error']['trainingId'] == 'find') {
-                    $parameters['trainingId'] = $training->id;
-                }
+            if (
+                isset($data['data_error']['trainingId']) &&
+                $data['data_error']['trainingId'] == 'find'
+            ) {
+                $parameters['trainingId'] = $training->id;
             }
         }
 
@@ -344,10 +345,11 @@ class ConfirmationTrainingTest extends TestCase
             ];
         } else {
             $parameters = $data['data_error'];
-            if (isset($data['data_error']['trainingId'])) {
-                if ($data['data_error']['trainingId'] == 'find') {
-                    $parameters['trainingId'] = $training->id;
-                }
+            if (
+                isset($data['data_error']['trainingId']) &&
+                $data['data_error']['trainingId'] == 'find'
+            ) {
+                $parameters['trainingId'] = $training->id;
             }
         }
 

--- a/tests/Feature/GraphQL/ConfirmationTrainingTest.php
+++ b/tests/Feature/GraphQL/ConfirmationTrainingTest.php
@@ -288,7 +288,8 @@ class ConfirmationTrainingTest extends TestCase
         $typeMessageError,
         $expectedMessage,
         $expected,
-        $hasPermission
+        bool $hasPermission,
+        bool $trainingCancelled
     ) {
         $team = Team::factory()
         ->hasPlayers(10)
@@ -296,6 +297,7 @@ class ConfirmationTrainingTest extends TestCase
 
         $training = Training::factory()
             ->setTeamId($team->id)
+            ->setStatus(!$trainingCancelled)
             ->create();
 
         if ($data['error'] === null) {
@@ -353,6 +355,7 @@ class ConfirmationTrainingTest extends TestCase
                     ],
                 ],
                 'hasPermission' => true,
+                'trainingCancelled' => false,
             ],
             'training confirmation for player not part of training, expected error' => [
                 [
@@ -374,6 +377,7 @@ class ConfirmationTrainingTest extends TestCase
                     'data' => $confirmationTraining,
                 ],
                 'hasPermission' => true,
+                'trainingCancelled' => false,
             ],
             'playerId must be a required field, expected error' => [
                 [
@@ -394,6 +398,7 @@ class ConfirmationTrainingTest extends TestCase
                     'data' => $confirmationTraining,
                 ],
                 'hasPermission' => true,
+                'trainingCancelled' => false,
             ],
             'trainingId must be a required field, expected error' => [
                 [
@@ -414,6 +419,7 @@ class ConfirmationTrainingTest extends TestCase
                     'data' => $confirmationTraining,
                 ],
                 'hasPermission' => true,
+                'trainingCancelled' => false,
             ],
             'status must be a required field, expected error' => [
                 [
@@ -431,6 +437,29 @@ class ConfirmationTrainingTest extends TestCase
                     'data' => $confirmationTraining,
                 ],
                 'hasPermission' => true,
+                'trainingCancelled' => false,
+            ],
+            'action validation with training canceled, expected error' => [
+                [
+                    'error' => true,
+                    'data_error' => [
+                        // TODO - Colocar aqui um objeto cadastrado para fazer o teste correto e fazer a nova validação
+                        'id' => 9999,
+                        'playerId' => 9999,
+                        'status' => [
+                            'type' => 'ENUM',
+                            'value' => 'CONFIRMED',
+                        ],
+                    ],
+                ],
+                'type_message_error' => 'trainingId',
+                'expected_message' => 'CheckPlayerIsInTraining.trainingId_required',
+                'expected' => [
+                    'errors' => $this->errors,
+                    'data' => $confirmationTraining,
+                ],
+                'hasPermission' => true,
+                'trainingCancelled' => true,
             ],
         ];
     }

--- a/tests/Feature/GraphQL/TrainingTest.php
+++ b/tests/Feature/GraphQL/TrainingTest.php
@@ -579,7 +579,7 @@ class TrainingTest extends TestCase
 
         $parameters['teamId'] = $team->id;
 
-        if($cancellation) {
+        if ($cancellation) {
             $parameters['status'] = false;
         }
 

--- a/tests/Feature/GraphQL/TrainingTest.php
+++ b/tests/Feature/GraphQL/TrainingTest.php
@@ -551,14 +551,18 @@ class TrainingTest extends TestCase
         $typeMessageError,
         $expectedMessage,
         $expected,
-        bool $hasPermission
+        bool $hasPermission,
+        bool $cancellation
     ) {
         $this->setPermissions($hasPermission);
 
         $this->be(User::find(3));
 
-        $training = Training::factory()->make();
+        $training = Training::factory()
+            ->setStatus($parameters['status'])
+            ->make();
         $training->save();
+
         $parameters['id'] = $training->id;
 
         $team = Team::factory()
@@ -574,6 +578,10 @@ class TrainingTest extends TestCase
         $team->save();
 
         $parameters['teamId'] = $team->id;
+
+        if($cancellation) {
+            $parameters['status'] = false;
+        }
 
         $response = $this->graphQL(
             'trainingEdit',
@@ -628,6 +636,7 @@ class TrainingTest extends TestCase
                     'userId' => $userId,
                     'dateStart' => $dateStart,
                     'dateEnd' => $dateEnd,
+                    'status' => true,
                 ],
                 'type_message_error' => false,
                 'expected_message' => false,
@@ -637,6 +646,7 @@ class TrainingTest extends TestCase
                     ],
                 ],
                 'hasPermission' => true,
+                'cancellation' => false,
             ],
             'edit training with full parameters, success' => [
                 [
@@ -645,6 +655,7 @@ class TrainingTest extends TestCase
                     'description' => $faker->text,
                     'dateStart' => $dateStart,
                     'dateEnd' => $dateEnd,
+                    'status' => true,
                 ],
                 'type_message_error' => false,
                 'expected_message' => false,
@@ -654,6 +665,7 @@ class TrainingTest extends TestCase
                     ],
                 ],
                 'hasPermission' => true,
+                'cancellation' => false,
             ],
             'edit training with relationship fundamentals, success' => [
                 [
@@ -662,6 +674,7 @@ class TrainingTest extends TestCase
                     'description' => $faker->text,
                     'dateStart' => $dateStart,
                     'dateEnd' => $dateEnd,
+                    'status' => true,
                     'fundamentalId' => [1, 2, 3],
                 ],
                 'type_message_error' => false,
@@ -672,6 +685,7 @@ class TrainingTest extends TestCase
                     ],
                 ],
                 'hasPermission' => true,
+                'cancellation' => false,
             ],
             'edit training with relationship specific fundamental, success' => [
                 [
@@ -680,6 +694,7 @@ class TrainingTest extends TestCase
                     'description' => $faker->text,
                     'dateStart' => $dateStart,
                     'dateEnd' => $dateEnd,
+                    'status' => true,
                     'fundamentalId' => [1],
                     'specificFundamentalId' => [1, 2, 3],
                 ],
@@ -691,13 +706,14 @@ class TrainingTest extends TestCase
                     ],
                 ],
                 'hasPermission' => true,
+                'cancellation' => false,
             ],
             'edit training cancel, success' => [
                 [
                     'name' => $nameExistent,
                     'userId' => $userId,
                     'description' => $faker->text,
-                    'status' => false,
+                    'status' => true,
                     'dateStart' => $dateStart,
                     'dateEnd' => $dateEnd,
                 ],
@@ -709,6 +725,7 @@ class TrainingTest extends TestCase
                     ],
                 ],
                 'hasPermission' => true,
+                'cancellation' => true,
             ],
             'edit training reactivate, success' => [
                 [
@@ -727,6 +744,7 @@ class TrainingTest extends TestCase
                     ],
                 ],
                 'hasPermission' => true,
+                'cancellation' => false,
             ],
             'edit training with notification if training date is current day, success' => [
                 [
@@ -745,6 +763,7 @@ class TrainingTest extends TestCase
                     ],
                 ],
                 'hasPermission' => true,
+                'cancellation' => false,
             ],
         ];
     }

--- a/tests/Feature/GraphQL/TrainingTest.php
+++ b/tests/Feature/GraphQL/TrainingTest.php
@@ -793,6 +793,7 @@ class TrainingTest extends TestCase
                     'userId' => $userId,
                     'dateStart' => $dateStart,
                     'dateEnd' => $dateEnd,
+                    'status' => true,
                 ],
                 'type_message_error' => false,
                 'expected_message' => false,
@@ -801,6 +802,7 @@ class TrainingTest extends TestCase
                     'data' => $trainingEdit,
                 ],
                 'hasPermission' => false,
+                'cancellation' => false,
             ],
             'name field is required, expected error' => [
                 [
@@ -808,6 +810,7 @@ class TrainingTest extends TestCase
                     'userId' => $userId,
                     'dateStart' => $dateStart,
                     'dateEnd' => $dateEnd,
+                    'status' => true,
                 ],
                 'type_message_error' => 'name',
                 'expected_message' => 'TrainingCreate.name_required',
@@ -816,6 +819,7 @@ class TrainingTest extends TestCase
                     'data' => $trainingEdit,
                 ],
                 'hasPermission' => true,
+                'cancellation' => false,
             ],
             'name field is min 3 characteres, expected error' => [
                 [
@@ -823,6 +827,7 @@ class TrainingTest extends TestCase
                     'userId' => $userId,
                     'dateStart' => $dateStart,
                     'dateEnd' => $dateEnd,
+                    'status' => true,
                 ],
                 'type_message_error' => 'name',
                 'expected_message' => 'TrainingCreate.name_min',
@@ -831,6 +836,7 @@ class TrainingTest extends TestCase
                     'data' => $trainingEdit,
                 ],
                 'hasPermission' => true,
+                'cancellation' => false,
             ],
             'DateStart must be less than dateEnd, expected error' => [
                 [
@@ -838,6 +844,7 @@ class TrainingTest extends TestCase
                     'userId' => $userId,
                     'dateStart' => $this->dateStart,
                     'dateEnd' => $this->dateEnd,
+                    'status' => true,
                 ],
                 'type_message_error' => 'dateStart',
                 'expected_message' => 'TrainingEdit.date_start_before',
@@ -846,6 +853,7 @@ class TrainingTest extends TestCase
                     'data' => $trainingEdit,
                 ],
                 'hasPermission' => true,
+                'cancellation' => false,
             ],
             'DateEnd must be greater than dateStart, expected error' => [
                 [
@@ -853,6 +861,7 @@ class TrainingTest extends TestCase
                     'userId' => $userId,
                     'dateStart' => $this->dateStart,
                     'dateEnd' => $this->dateEnd,
+                    'status' => true,
                 ],
                 'type_message_error' => 'dateEnd',
                 'expected_message' => 'TrainingEdit.date_end_after',
@@ -861,6 +870,7 @@ class TrainingTest extends TestCase
                     'data' => $trainingEdit,
                 ],
                 'hasPermission' => true,
+                'cancellation' => false,
             ],
             'DateEnd without correct formatting, expected error' => [
                 [
@@ -868,6 +878,7 @@ class TrainingTest extends TestCase
                     'userId' => $userId,
                     'dateStart' => $this->dateStart,
                     'dateEnd' => '08/10/2022 13:45:00',
+                    'status' => true,
                 ],
                 'type_message_error' => 'dateEnd',
                 'expected_message' => 'TrainingEdit.date_end_date_format',
@@ -876,6 +887,7 @@ class TrainingTest extends TestCase
                     'data' => $trainingEdit,
                 ],
                 'hasPermission' => true,
+                'cancellation' => false,
             ],
             'DateStart without correct formatting, expected error' => [
                 [
@@ -883,6 +895,7 @@ class TrainingTest extends TestCase
                     'userId' => $userId,
                     'dateStart' => $this->dateStartError,
                     'dateEnd' => $this->dateEndError,
+                    'status' => true,
                 ],
                 'type_message_error' => 'dateStart',
                 'expected_message' => 'TrainingEdit.date_start_date_format',
@@ -891,6 +904,7 @@ class TrainingTest extends TestCase
                     'data' => $trainingEdit,
                 ],
                 'hasPermission' => true,
+                'cancellation' => false,
             ],
             'specific fundamentals unrelated to fundamentals on record, expected error' => [
                 [
@@ -898,6 +912,7 @@ class TrainingTest extends TestCase
                     'userId' => $userId,
                     'dateStart' => $this->dateStartError,
                     'dateEnd' => $this->dateEndError,
+                    'status' => true,
                     'fundamentalId' => [1],
                     'specificFundamentalId' => [13],
                 ],
@@ -908,6 +923,7 @@ class TrainingTest extends TestCase
                     'data' => $trainingEdit,
                 ],
                 'hasPermission' => true,
+                'cancellation' => false,
             ],
         ];
     }

--- a/tests/Unit/App/Mail/Training/CancellationNotificationTrainingMailTest.php
+++ b/tests/Unit/App/Mail/Training/CancellationNotificationTrainingMailTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Unit\App\Mail\Training;
+
+use App\Mail\Training\CancellationNotificationTrainingMail;
+use App\Models\Training;
+use App\Models\User;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Tests\TestCase;
+
+class CancellationNotificationTrainingMailTest extends TestCase
+{
+    public $dateStart = '2020-01-01 00:00:00';
+
+    /**
+     * A method to test the envelope.
+     *
+     * @test
+     *
+     * @return void
+     */
+    public function envelope()
+    {
+        $trainingMock = $this->mock(Training::class, function ($mock) {
+            $mock->shouldReceive('getAttribute')->with('date_start')->andReturn(
+                \Carbon\Carbon::parse($this->dateStart)
+            );
+            $mock->shouldReceive('getAttribute')->with('date_end')->andReturn(
+                \Carbon\Carbon::parse($this->dateStart)
+            );
+            $mock->shouldReceive('getAttribute')->with('name')->andReturn(
+                'Test name'
+            );
+        });
+
+        $userMock = $this->createMock(User::class);
+        $mail = new CancellationNotificationTrainingMail($trainingMock, $userMock);
+        $envelope = $mail->envelope();
+
+        $this->assertInstanceOf(Envelope::class, $envelope);
+    }
+
+    /**
+     * A method to test the content.
+     *
+     * @test
+     *
+     * @return void
+     */
+    public function content()
+    {
+        $trainingMock = $this->mock(Training::class, function ($mock) {
+            $mock->shouldReceive('getAttribute')->with('date_start')->andReturn(
+                \Carbon\Carbon::parse($this->dateStart)
+            );
+            $mock->shouldReceive('getAttribute')->with('date_end')->andReturn(
+                \Carbon\Carbon::parse($this->dateStart)
+            );
+            $mock->shouldReceive('getAttribute')->with('name')->andReturn(
+                'Test name'
+            );
+        });
+
+        $userMock = $this->createMock(User::class);
+        $mail = new CancellationNotificationTrainingMail($trainingMock, $userMock);
+        $content = $mail->content();
+
+        $this->assertInstanceOf(Content::class, $content);
+    }
+}

--- a/tests/Unit/App/Rules/CheckTrainingCancelledTest.php
+++ b/tests/Unit/App/Rules/CheckTrainingCancelledTest.php
@@ -47,10 +47,8 @@ class CheckTrainingTestCancelled extends TestCase
 
                 $mock->shouldReceive('find')
                     ->once()
-                    ->with( 1)
+                    ->with(1)
                     ->andReturnSelf();
-                
-                
             }
         );
 

--- a/tests/Unit/App/Rules/CheckTrainingCancelledTest.php
+++ b/tests/Unit/App/Rules/CheckTrainingCancelledTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Unit\App\Rules;
+
+use App\Models\Training;
+use App\Rules\CheckTrainingCancelled;
+use Mockery\MockInterface;
+use Tests\TestCase;
+
+class CheckTrainingTestCancelled extends TestCase
+{
+    /**
+     * A basic unit test message.
+     *
+     * @test
+     *
+     * @return void
+     */
+    public function message()
+    {
+        $trainingId = 1;
+        $training = $this->createMock(Training::class);
+
+        $permissionAssignment = new CheckTrainingCancelled($trainingId, $training);
+        $this->assertIsString($permissionAssignment->message());
+    }
+
+    /**
+     * A basic unit test passes.
+     *
+     * @test
+     *
+     * @dataProvider passesProvider
+     *
+     * @return void
+     */
+    public function passes($passes)
+    {
+        $trainingId = 1;
+        $trainingMock = $this->mock(
+            Training::class,
+            function (MockInterface $mock) use ($passes) {
+                $mock->shouldReceive('getAttribute')
+                    ->once()
+                    ->with('status')
+                    ->andReturn($passes);
+
+                $mock->shouldReceive('find')
+                    ->once()
+                    ->with( 1)
+                    ->andReturnSelf();
+                
+                
+            }
+        );
+
+        $permissionAssignment = new CheckTrainingCancelled($trainingId, $trainingMock);
+        $this->assertEquals($permissionAssignment->passes('player_id', $trainingId), $passes);
+    }
+
+    public function passesProvider()
+    {
+        return [
+            'when there is player related to training' => [
+                'passes' => true,
+            ],
+            'if there is no player related to training' => [
+                'passes' => false,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
### O que?

Adicionado ações de cancelamento de treino. Juntamente com as validações de:
* Impedir que um jogador confirme ir a um treino cancelado
* Impedir que um técnico marque presença de um jogador a um treino cancelado

### Por quê?

Ao cancelar um treino os usuários (jogadores) devem ser notificados da ação.

### Como?

Adicionado validações para confirmação de treino, e de presença no treino.

