### PR TITLE
Horizon: Adicionado opção de visualização de métricas do Laravel Horizon

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -24,6 +24,8 @@ class Kernel extends ConsoleKernel
     {
         $output = storage_path('app/output.txt');
 
+        $schedule->command('horizon:snapshot')->everyFiveMinutes();
+
         $tenants = Tenant::where('id', 'NOT LIKE', '%_logs')->pluck('id');
 
         foreach ($tenants as $tenant) {


### PR DESCRIPTION
### O que?

Adicionado função para gerar as métricas do Laravel Horizon

### Por quê?

Sem a função as métricas não eram geradas.

### Como?

No arquivo `app/Console/Kernel.php` é adicionado:

```php
$schedule->command('horizon:snapshot')->everyFiveMinutes();
```

Para que o processo execute de cinco em cinco mínutos.

### Capturas de tela

![image](https://user-images.githubusercontent.com/25940408/219216356-b80f768d-e47f-4e84-9301-731f2039de93.png)


