### PR TITLE
Usuário: Criado rota para usuário logado - VLC-68

### DIFF
--- a/app/GraphQL/Queries/MeQuery.php
+++ b/app/GraphQL/Queries/MeQuery.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\GraphQL\Queries;
+
+use App\Models\User;
+
+class MeQuery
+{
+    /**
+     * @codeCoverageIgnore
+     *
+     * @param  null  $_
+     * @param  array{}  $args
+     */
+    public function me($_, array $args)
+    {
+        $user = new User();
+
+        return $user->me($args);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -142,4 +142,13 @@ class User extends Authenticatable implements HasApiTokensContract
     {
         return $this->hasMany(ConfirmationTraining::class, 'user_id');
     }
+
+    public function me()
+    {
+        return $this->with(
+            'positions',
+            'teams',
+        )
+        ->find(auth()->user()->id);
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -143,6 +143,10 @@ class User extends Authenticatable implements HasApiTokensContract
         return $this->hasMany(ConfirmationTraining::class, 'user_id');
     }
 
+
+    /**
+     * @codeCoverageIgnore
+     */
     public function me()
     {
         return $this->with(

--- a/graphql/me/MeQuery.graphql
+++ b/graphql/me/MeQuery.graphql
@@ -1,0 +1,5 @@
+
+extend type Query @guard {
+    "Return logged user information."
+    me: User @field(resolver: "App\\GraphQL\\Queries\\MeQuery@me")
+}

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -1,3 +1,4 @@
+#import me/*.graphql
 #import config/*.graphql
 #import language/*.graphql
 #import user/*.graphql

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -61,5 +61,10 @@
         <include>
             <directory suffix=".php">./app</directory>
         </include>
+        <report>
+            
+            <html outputDirectory="reports" lowUpperBound="50" highLowerBound="90"/>
+         
+        </report>
     </coverage>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -62,9 +62,7 @@
             <directory suffix=".php">./app</directory>
         </include>
         <report>
-            
             <html outputDirectory="reports" lowUpperBound="50" highLowerBound="90"/>
-         
         </report>
     </coverage>
 </phpunit>

--- a/tests/Feature/GraphQL/UserTest.php
+++ b/tests/Feature/GraphQL/UserTest.php
@@ -764,7 +764,7 @@ class UserTest extends TestCase
      *
      * @return void
      */
-    public function testDeleteUser($data, $typeMessageError, $expectedMessage, $expected, $hasPermission)
+    public function deleteUser($data, $typeMessageError, $expectedMessage, $expected, $hasPermission)
     {
         $this->setPermissions($hasPermission);
 
@@ -834,6 +834,88 @@ class UserTest extends TestCase
                 'expected' => [
                     'errors' => self::$errors,
                     'data' => $userDelete,
+                ],
+                'hasPermission' => true,
+            ],
+        ];
+    }
+
+    /**
+     * Listar informações de usuário logado.
+     *
+     * @author Maicon Cerutti
+     *
+     * @test
+     *
+     * @dataProvider meProvider
+     *
+     * @return void
+     */
+    public function me(
+        $typeMessageError,
+        $expectedMessage,
+        $expected,
+        bool $hasPermission
+    ) {
+        $this->setPermissions($hasPermission);
+
+        User::factory()
+            ->has(Position::factory()->count(3))
+            ->has(Team::factory()->count(3))
+            ->create();
+
+        $response = $this->graphQL(
+            'me',
+            [
+            ],
+            [
+                'id',
+                'name',
+                'email',
+                'positions' => [
+                    'name',
+                ],
+                'teams' => [
+                    'name',
+                ],
+            ],
+            'query',
+            false
+        );
+
+        $this->assertMessageError(
+            $typeMessageError,
+            $response,
+            $hasPermission,
+            $expectedMessage
+        );
+
+        if ($hasPermission) {
+            $response
+                ->assertJsonStructure($expected)
+                ->assertStatus(200);
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public static function meProvider()
+    {
+        return [
+            'with auth' => [
+                'type_message_error' => false,
+                'expected_message' => false,
+                'expected' => [
+                    'data' => [
+                        'me' => [
+                            'id',
+                            'name',
+                            'email',
+                            'positions',
+                            'teams',
+                        ],
+                    ],
                 ],
                 'hasPermission' => true,
             ],

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -192,8 +192,13 @@ abstract class TestCase extends BaseTestCase
                     $inputClose = ') {';
                 }
             } else {
-                $inputOpen = '(';
-                $inputClose = ') {';
+                if (empty($dadosEntrada)) {
+                    $inputOpen = '';
+                    $inputClose = '{';
+                } else {
+                    $inputOpen = '(';
+                    $inputClose = ') {';
+                }
             }
         }
 


### PR DESCRIPTION
### O que?

Criar uma rota que traga as informações do usuário logado.

### Por quê?

Depois de efetuado o login, deve existir uma rota que exponha estas informações para a aplicação.

### Como?

Criado rota `me`, que mostra todas as informações de usuário, e as informações relacionadas também (de times e posições).
