### PR TITLE
Laravel Horizon: Adicionado tags de marcação para processos em segundo plano - VLC-69

### DIFF
--- a/app/Jobs/ExecCommand.php
+++ b/app/Jobs/ExecCommand.php
@@ -46,4 +46,14 @@ class ExecCommand implements ShouldQueue
     {
         Artisan::call("$this->command --multi_tenants=$this->tenant");
     }
+
+    /**
+     * Get the tags that should be assigned to the job.
+     *
+     * @return array<int, string>
+     */
+    public function tags(): array
+    {
+        return ['tenant:' . $this->tenant];
+    }
 }

--- a/app/Notifications/Training/Notification.php
+++ b/app/Notifications/Training/Notification.php
@@ -18,6 +18,8 @@ class Notification extends IlluminateNotification implements ShouldQueue
 
     public $confirmationTraining;
 
+    public $tenant;
+
     /**
      * Create a new notification instance.
      *
@@ -27,6 +29,7 @@ class Notification extends IlluminateNotification implements ShouldQueue
     {
         $this->training = $training;
         $this->confirmationTraining = $confirmationTraining;
+        $this->tenant = tenant('id');
         $this->afterCommit();
     }
 
@@ -63,5 +66,15 @@ class Notification extends IlluminateNotification implements ShouldQueue
         }
 
         return ['database'];
+    }
+
+    /**
+     * Get the tags that should be assigned to the job.
+     *
+     * @return array<int, string>
+     */
+    public function tags(): array
+    {
+        return ['tenant:' . $this->tenant];
     }
 }


### PR DESCRIPTION
### O que?

Adicionado tags de marcação para processos em execução em segundo plano.

### Por quê?

Para que os processos em segundo plano poderem ser destacados com maior facilidade dentro do Laravel Horizon.

### Como?

Adicionado função `tags` para o `Notification.php` e para o arquivo `ExecCommand.php` que executa os processos em segundo plano do Laravel Horizon.