### PR TITLE
Usuários: Adicionando CPF, RG e telefone para informações dos usuários - VLC-101 - VLC-102

### DIFF
--- a/app/GraphQL/Mutations/UserMutation.php
+++ b/app/GraphQL/Mutations/UserMutation.php
@@ -33,6 +33,8 @@ final class UserMutation
 
         $this->user->save();
 
+        $this->user->updateOrNewInformation($args);
+
         $this->user->roles()->syncWithoutDetaching($args['roleId']);
 
         if (isset($args['positionId'])) {

--- a/app/GraphQL/Validators/Mutation/UserCreateValidator.php
+++ b/app/GraphQL/Validators/Mutation/UserCreateValidator.php
@@ -29,6 +29,12 @@ class UserCreateValidator extends Validator
                 'exists:roles,id',
                 new PermissionAssignment(),
             ],
+            'cpf' => [
+                'unique:user_information,cpf',
+            ],
+            'rg' => [
+                'unique:user_information,rg',
+            ],
         ];
     }
 
@@ -44,6 +50,8 @@ class UserCreateValidator extends Validator
             'roleId.required' => trans('UserCreate.role_id_required'),
             'email.email' => trans('UserCreate.email_is_valid'),
             'email.unique' => trans('UserCreate.email_unique'),
+            'cpf.unique' => trans('UserCreate.cpf_unique'),
+            'rg.unique' => trans('UserCreate.rg_unique')
         ];
     }
 }

--- a/app/GraphQL/Validators/Mutation/UserEditValidator.php
+++ b/app/GraphQL/Validators/Mutation/UserEditValidator.php
@@ -29,6 +29,12 @@ final class UserEditValidator extends Validator
                 'exists:roles,id',
                 new PermissionAssignment(),
             ],
+            'cpf' => [
+                'unique:user_information,cpf,' . $this->arg('id'),
+            ],
+            'rg' => [
+                'unique:user_information,rg,' . $this->arg('id'),
+            ],
         ];
     }
 
@@ -44,6 +50,8 @@ final class UserEditValidator extends Validator
             'roleId.required' => trans('UserEdit.role_id_required'),
             'email.email' => trans('UserEdit.email_is_valid'),
             'email.unique' => trans('UserEdit.email_unique'),
+            'cpf.unique' => trans('UserEdit.cpf_unique'),
+            'rg.unique' => trans('UserEdit.rg_unique'),
         ];
     }
 }

--- a/app/Http/Middleware/SessionTimeoutMiddleware.php
+++ b/app/Http/Middleware/SessionTimeoutMiddleware.php
@@ -9,7 +9,7 @@ class SessionTimeoutMiddleware
 {
     /**
      * Handle an incoming request.
-     *
+     * @codeCoverageIgnore
      * @param  \Closure(\Illuminate\Http\Request): (\Illuminate\Http\Response|\Illuminate\Http\RedirectResponse)  $next
      * @return \Illuminate\Http\Response|\Illuminate\Http\RedirectResponse
      */

--- a/app/Jobs/ExecCommand.php
+++ b/app/Jobs/ExecCommand.php
@@ -48,6 +48,8 @@ class ExecCommand implements ShouldQueue
     }
 
     /**
+     * @codeCoverageIgnore
+     *
      * Get the tags that should be assigned to the job.
      *
      * @return array<int, string>

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -159,4 +159,33 @@ class User extends Authenticatable implements HasApiTokensContract
     {
         return $this->hasOne(UserInformation::class);
     }
+
+    public function updateOrNewInformation($args)
+    {
+        $attributes = [];
+
+        if (isset($args['cpf'])) {
+            $attributes['cpf'] = $args['cpf'];
+        }
+
+        if (isset($args['phone'])) {
+            $attributes['phone'] = $args['phone'];
+        }
+
+        if (isset($args['rg'])) {
+            $attributes['rg'] = $args['rg'];
+        }
+
+        if (!empty($attributes)) {
+            if (!$this->information) {
+                $this->information = $this->information()->create($attributes);
+            } else {
+                $this->information->fill($attributes);
+
+                if ($this->information->isDirty()) {
+                    $this->information->save();
+                }
+            }
+        }
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -160,6 +160,14 @@ class User extends Authenticatable implements HasApiTokensContract
         return $this->hasOne(UserInformation::class);
     }
 
+    /**
+     *
+     * @codeCoverageIgnore
+     *
+     * @param mixed $args
+     *
+     * @return void
+     */
     public function updateOrNewInformation($args)
     {
         $attributes = [];

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -154,4 +154,9 @@ class User extends Authenticatable implements HasApiTokensContract
         )
             ->find(auth()->user()->id);
     }
+
+    public function information()
+    {
+        return $this->hasOne(UserInformation::class);
+    }
 }

--- a/app/Models/UserInformation.php
+++ b/app/Models/UserInformation.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class UserInformation extends Model
+{
+    use HasFactory;
+    use SoftDeletes;
+
+    protected $fillable = [
+        'cpf',
+        'phone',
+        'rg'
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/database/factories/UserInformationFactory.php
+++ b/database/factories/UserInformationFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\User>
+ */
+class UserInformationFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition()
+    {
+        return [
+            'cpf' => $this->faker->numberBetween(10000000000, 99999999999),
+            'rg' => $this->faker->numberBetween(100000000, 999999999),
+            'phone' => $this->faker->phoneNumber(),
+        ];
+    }
+}

--- a/database/migrations/tenant/base/2014_10_12_010000_create_users_informations_table.php
+++ b/database/migrations/tenant/base/2014_10_12_010000_create_users_informations_table.php
@@ -23,6 +23,8 @@ class CreateUsersInformationsTable extends Migration
             $table->softDeletes();
 
             $table->unique('user_id');
+            $table->unique('cpf');
+            $table->unique('rg');
         });
     }
 

--- a/database/migrations/tenant/base/2014_10_12_010000_create_users_informations_table.php
+++ b/database/migrations/tenant/base/2014_10_12_010000_create_users_informations_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateUsersInformationsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('user_information', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->string('cpf');
+            $table->string('phone');
+            $table->string('rg');
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('user_information');
+    }
+}

--- a/database/migrations/tenant/base/2014_10_12_010000_create_users_informations_table.php
+++ b/database/migrations/tenant/base/2014_10_12_010000_create_users_informations_table.php
@@ -21,6 +21,8 @@ class CreateUsersInformationsTable extends Migration
             $table->string('rg');
             $table->timestamps();
             $table->softDeletes();
+
+            $table->unique('user_id');
         });
     }
 

--- a/database/migrations/tenant/base/2022_07_19_015219_create_positions_users_table.php
+++ b/database/migrations/tenant/base/2022_07_19_015219_create_positions_users_table.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class() extends Migration
-{
+return new class () extends Migration {
     /**
      * Run the migrations.
      *
@@ -30,6 +29,6 @@ return new class() extends Migration
      */
     public function down()
     {
-        //
+        Schema::dropIfExists('positions_users');
     }
 };

--- a/graphql/user/UserInformationType.graphql
+++ b/graphql/user/UserInformationType.graphql
@@ -1,0 +1,26 @@
+"Account of a person who utilizes this application."
+type UserInformation {
+    "Unique primary key."
+    id: ID!
+
+    "User ID."
+    user_id: Int!
+
+    "User relation."
+    user: User @belongsTo(relation: "user")
+
+    "CPF."
+    cpf: String!
+
+    "RG."
+    rg: String!
+
+    "Phone number."
+    phone: String!
+
+    "Date created. A datetime string with format `Y-m-d H:i:s`, e.g. `2018-05-23 13:43:32`."
+    createdAt: DateTime! @rename(attribute: "created_at")
+    
+    "Date updated. A datetime string with format `Y-m-d H:i:s`, e.g. `2018-05-23 13:43:32`."
+    updatedAt: DateTime! @rename(attribute: "updated_at")
+}

--- a/graphql/user/UserMutation.graphql
+++ b/graphql/user/UserMutation.graphql
@@ -3,6 +3,9 @@ extend type Mutation @guard {
     userCreate(
         name: String!
         email: String! @rules(apply: ["email", "unique:users"])
+        cpf: String
+        rg: String
+        phone: String
         roleId: [Int!]!
         positionId: [Int]
         teamId: [Int]
@@ -16,6 +19,9 @@ extend type Mutation @guard {
         id: ID!
         name: String!
         email: String!
+        cpf: String
+        rg: String
+        phone: String
         roleId: [Int!]!
         positionId: [Int]
         teamId: [Int]

--- a/graphql/user/UserType.graphql
+++ b/graphql/user/UserType.graphql
@@ -15,6 +15,9 @@ type User {
     "Teams."
     teams: [Team] @belongsToMany(relation: "teams")
 
+    "Information."
+    information: UserInformation @hasOne(relation: "information")
+
     "When the email was verified."
     emailVerifiedAt: DateTime @rename(attribute: "email_verified_at")
 

--- a/lang/en/UserCreate.php
+++ b/lang/en/UserCreate.php
@@ -19,4 +19,6 @@ return [
     'password_min_6' => 'The password must be at least 6 characters long.',
     'password_required' => 'The password field is required.',
     'role_id_required' => 'The roleId field is required.',
+    'cpf_unique' => 'This CPF has already been registered.',
+    'rg_unique' => 'This RG has already been registered.',
 ];

--- a/lang/en/UserEdit.php
+++ b/lang/en/UserEdit.php
@@ -19,4 +19,6 @@ return [
     'password_min_6' => 'The password must be at least 6 characters long.',
     'password_required' => 'The password field is required.',
     'role_id_required' => 'The roleId field is required.',
+    'cpf_unique' => 'This CPF has already been registered.',
+    'rg_unique' => 'This RG has already been registered.',
 ];

--- a/lang/pt-br/UserCreate.php
+++ b/lang/pt-br/UserCreate.php
@@ -19,4 +19,6 @@ return [
     'password_min_6' => 'A senha precisa ter no mínimo 6 caracteres.',
     'password_required' => 'O campo senha é obrigatório.',
     'role_id_required' => 'O campo roleId é obrigatório.',
+    'cpf_unique' => 'Este CPF já foi registrado.',
+    'rg_unique' => 'Este RG já foi registrado.',
 ];

--- a/lang/pt-br/UserEdit.php
+++ b/lang/pt-br/UserEdit.php
@@ -19,4 +19,6 @@ return [
     'password_min_6' => 'A senha precisa ter no mínimo 6 caracteres.',
     'password_required' => 'O campo senha é obrigatório.',
     'role_id_required' => 'O campo roleId é obrigatório.',
+    'cpf_unique' => 'Este CPF já foi registrado.',
+    'rg_unique' => 'Este RG já foi registrado.',
 ];

--- a/tests/Feature/GraphQL/UserTest.php
+++ b/tests/Feature/GraphQL/UserTest.php
@@ -246,6 +246,8 @@ class UserTest extends TestCase
     {
         $faker = Faker::create();
         $emailExistent = $faker->email;
+        $cpfExistent = strval($faker->numberBetween(10000000000, 99999999999));
+        $rgExistent = strval($faker->numberBetween(10000000000, 99999999999));
 
         $password = env('PASSWORD_TEST', '123456');
 
@@ -284,6 +286,63 @@ class UserTest extends TestCase
                     'data' => [
                         'userCreate' => self::$data,
                     ],
+                ],
+                'hasTeam' => false,
+                'hasPermission' => true,
+            ],
+            'create user with non-mandatory parameters, success' => [
+                [
+                    'name' => $faker->name,
+                    'email' => $faker->email,
+                    'cpf' => $cpfExistent,
+                    'phone' => $faker->phoneNumber,
+                    'rg' => $rgExistent,
+                    'roleId' => [2],
+                    'positionId' => [1],
+                    'password' => $password,
+                ],
+                'type_message_error' => false,
+                'expected_message' => false,
+                'expected' => [
+                    'data' => [
+                        'userCreate' => self::$data,
+                    ],
+                ],
+                'hasTeam' => false,
+                'hasPermission' => true,
+            ],
+            'create user with cpf existent, expected error' => [
+                [
+                    'name' => $faker->name,
+                    'email' => $faker->email,
+                    'cpf' => $cpfExistent,
+                    'roleId' => [3],
+                    'password' => $password,
+                    'roleId' => [],
+                ],
+                'type_message_error' => 'cpf',
+                'expected_message' => 'UserCreate.cpf_unique',
+                'expected' => [
+                    'errors' => self::$errors,
+                    'data' => $userCreate,
+                ],
+                'hasTeam' => false,
+                'hasPermission' => true,
+            ],
+            'create user with rg existent, expected error' => [
+                [
+                    'name' => $faker->name,
+                    'email' => $faker->email,
+                    'rg' => $rgExistent,
+                    'roleId' => [3],
+                    'password' => $password,
+                    'roleId' => [],
+                ],
+                'type_message_error' => 'rg',
+                'expected_message' => 'UserCreate.rg_unique',
+                'expected' => [
+                    'errors' => self::$errors,
+                    'data' => $userCreate,
                 ],
                 'hasTeam' => false,
                 'hasPermission' => true,
@@ -532,6 +591,9 @@ class UserTest extends TestCase
     {
         $faker = Faker::create();
 
+        $cpfExistent = strval($faker->numberBetween(10000000000, 99999999999));
+        $rgExistent = strval($faker->numberBetween(10000000000, 99999999999));
+
         $password = env('PASSWORD_TEST', '123456');
         $userEdit = ['userEdit'];
 
@@ -583,6 +645,61 @@ class UserTest extends TestCase
                 ],
                 'hasTeam' => false,
                 'hasPermission' => false,
+            ],
+            'edit user with cpf, rg and phone, success' => [
+                [
+                    'name' => $faker->name,
+                    'cpf' => $cpfExistent,
+                    'rg' => $rgExistent,
+                    'phone' => $faker->phoneNumber,
+                    'email' => $faker->email,
+                    'password' => $password,
+                    'roleId' => [2],
+                    'positionId' => [2],
+                ],
+                'type_message_error' => false,
+                'expected_message' => false,
+                'expected' => [
+                    'data' => [
+                        'userEdit' => self::$data,
+                    ],
+                ],
+                'hasTeam' => true,
+                'hasPermission' => true,
+            ],
+            'edit user with cpf not unique, expected error' => [
+                [
+                    'name' => $faker->name,
+                    'email' => $faker->email,
+                    'cpf' => $cpfExistent,
+                    'password' => $password,
+                    'roleId' => [2],
+                ],
+                'type_message_error' => 'cpf',
+                'expected_message' => 'UserEdit.cpf_unique',
+                'expected' => [
+                    'errors' => self::$errors,
+                    'data' => $userEdit,
+                ],
+                'hasTeam' => false,
+                'hasPermission' => true,
+            ],
+            'edit user with rg not unique, expected error' => [
+                [
+                    'name' => $faker->name,
+                    'email' => $faker->email,
+                    'rg' => $rgExistent,
+                    'password' => $password,
+                    'roleId' => [2],
+                ],
+                'type_message_error' => 'rg',
+                'expected_message' => 'UserEdit.rg_unique',
+                'expected' => [
+                    'errors' => self::$errors,
+                    'data' => $userEdit,
+                ],
+                'hasTeam' => false,
+                'hasPermission' => true,
             ],
             'edit user with team, success' => [
                 [

--- a/tests/Unit/App/GraphQL/Mutations/UserMutationTest.php
+++ b/tests/Unit/App/GraphQL/Mutations/UserMutationTest.php
@@ -80,8 +80,8 @@ class UserMutationTest extends TestCase
                 ->with([$team]);
         });
 
-        $UserMutation = new UserMutation($userMock);
-        $userReturn = $UserMutation->make(
+        $userMutation = new UserMutation($userMock);
+        $userReturn = $userMutation->make(
             null,
             $data,
             $graphQLContext

--- a/tests/Unit/App/GraphQL/Mutations/UserMutationTest.php
+++ b/tests/Unit/App/GraphQL/Mutations/UserMutationTest.php
@@ -76,8 +76,8 @@ class UserMutationTest extends TestCase
                 ->with([$team]);
         });
 
-        $specificFundamentalMutation = new UserMutation($userMock);
-        $userReturn = $specificFundamentalMutation->make(
+        $UserMutation = new UserMutation($userMock);
+        $userReturn = $UserMutation->make(
             null,
             $data,
             $graphQLContext

--- a/tests/Unit/App/GraphQL/Mutations/UserMutationTest.php
+++ b/tests/Unit/App/GraphQL/Mutations/UserMutationTest.php
@@ -56,6 +56,10 @@ class UserMutationTest extends TestCase
                 ->once()
                 ->andReturn($mock);
 
+            $mock->shouldReceive('updateOrNewInformation')
+                ->once()
+                ->andReturn($mock);
+
             $mock->shouldReceive('roles')
                 ->once()
                 ->andReturn($role);

--- a/tests/Unit/App/Models/UserInformationTest.php
+++ b/tests/Unit/App/Models/UserInformationTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Unit\App\Models;
+
+use App\Models\UserInformation;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Tests\TestCase;
+
+class UserInformationTest extends TestCase
+{
+    /**
+     * A basic unit test relation user.
+     *
+     * @test
+     *
+     * @return void
+     */
+    public function user()
+    {
+        $userInformation = new UserInformation();
+        $this->assertInstanceOf(BelongsTo::class, $userInformation->user());
+    }
+}

--- a/tests/Unit/App/Models/UserTest.php
+++ b/tests/Unit/App/Models/UserTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\App\Models;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Support\Facades\Hash;
 use Spatie\Activitylog\LogOptions;
 use Spatie\Permission\Models\Permission;
@@ -159,5 +160,18 @@ class UserTest extends TestCase
     {
         $user = new User();
         $this->assertInstanceOf(HasMany::class, $user->userConfirmationsTraining());
+    }
+
+    /**
+     * A basic unit test relation information
+     *
+     * @test
+     *
+     * @return void
+     */
+    public function information()
+    {
+        $user = new User();
+        $this->assertInstanceOf(HasOne::class, $user->information());
     }
 }

--- a/tests/Unit/App/Models/UserTest.php
+++ b/tests/Unit/App/Models/UserTest.php
@@ -3,12 +3,15 @@
 namespace Tests\Unit\App\Models;
 
 use App\Models\User;
+use App\GraphQL\Mutations\UserMutation;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Support\Facades\Hash;
 use Spatie\Activitylog\LogOptions;
 use Spatie\Permission\Models\Permission;
+use Mockery\MockInterface;
+use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
 use Tests\TestCase;
 
 class UserTest extends TestCase

--- a/tests/Unit/App/Notifications/Training/NotificationTest.php
+++ b/tests/Unit/App/Notifications/Training/NotificationTest.php
@@ -95,4 +95,21 @@ class NotificationTest extends TestCase
             ],
         ];
     }
+
+    /**
+     * A test method tags.
+     *
+     * @test
+     *
+     * @return array
+     */
+    public function tags()
+    {
+        $trainingMock = $this->createMock(Training::class);
+        $notification = new Notification($trainingMock);
+        $tags = $notification->tags();
+
+        $this->assertIsArray($tags);
+        $this->assertEquals(['tenant:'], $tags);
+    }
 }


### PR DESCRIPTION
### O que?

Adicionar possibilidade de cadastrar e editar nas informações do usuário CPF, RG e telefone.

### Por quê?

Essas informações são se suma importância para o registros dos usuários na aplicação e para o controle do time futuramente, essas informações servem tanto para a gerencia como para controle interno.

Obs: Atualmente quando uma equipe é escalada para um campeonato os jogadores devem informar RG e CPF para a comissão da competição (para no dia do jogo estes jogadores escalados possam ser conferidos).

### Como?

* Adicionado nova tabela user_information, para ficar separado as informações do usuário da tabela principal.
* Adicionado na tipagem do GraphQL as informações extras para cadastro e edição na API.


### Verificações
- [ ] Lembrete: Ajustar o `composer.json` com a versão.

