### PR TITLE
Jogadores: Fazendo os filtros padrão da listagem de jogadores - VLC-104

### DIFF
--- a/app/GraphQL/Queries/PositionQuery.php
+++ b/app/GraphQL/Queries/PositionQuery.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\GraphQL\Queries;
+
+use App\Models\Position;
+
+class PositionQuery
+{
+    /**
+     * @codeCoverageIgnore
+     *
+     * @param  null  $_
+     * @param  array{}  $args
+     */
+    public function list($_, array $args)
+    {
+        $position = new Position();
+
+        return $position->list($args);
+    }
+}

--- a/app/GraphQL/Queries/TeamQuery.php
+++ b/app/GraphQL/Queries/TeamQuery.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\GraphQL\Queries;
+
+use App\Models\Team;
+
+class TeamQuery
+{
+    /**
+     * @codeCoverageIgnore
+     *
+     * @param  null  $_
+     * @param  array{}  $args
+     */
+    public function list($_, array $args)
+    {
+        $team = new Team();
+
+        return $team->list($args);
+    }
+}

--- a/app/GraphQL/Queries/UserQuery.php
+++ b/app/GraphQL/Queries/UserQuery.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\GraphQL\Queries;
+
+use App\Models\User;
+
+class UserQuery
+{
+    /**
+     * @codeCoverageIgnore
+     *
+     * @param  null  $_
+     * @param  array{}  $args
+     */
+    public function list($_, array $args)
+    {
+        $user = new User();
+
+        return $user->list($args);
+    }
+}

--- a/app/Models/Position.php
+++ b/app/Models/Position.php
@@ -60,16 +60,19 @@ class Position extends Model
         $query->when(isset($args['filter']) && isset($args['filter']['search']), function ($query) use ($args) {
             $query->filterName($args['filter']['search']);
         });
-
-        return $query;
     }
 
     public function scopeFilterName(Builder $query, string $search)
     {
         $query->when(isset($search), function ($query) use ($search) {
-            $query->where('name', 'like', $search);
+            $query->where('positions.name', 'like', $search);
         });
+    }
 
-        return $query;
+    public function scopeFilterIds(Builder $query, array $ids)
+    {
+        $query->when(isset($ids) && !empty($ids), function ($query) use ($ids) {
+            $query->whereIn('positions.id', $ids);
+        });
     }
 }

--- a/app/Models/Position.php
+++ b/app/Models/Position.php
@@ -52,7 +52,8 @@ class Position extends Model
     public function list(array $args)
     {
         return $this
-            ->filterSearch($args);
+            ->filterSearch($args)
+            ->filterTeam($args);
     }
 
     public function scopeFilterSearch(Builder $query, array $args)
@@ -73,6 +74,17 @@ class Position extends Model
     {
         $query->when(isset($ids) && !empty($ids), function ($query) use ($ids) {
             $query->whereIn('positions.id', $ids);
+        });
+    }
+
+    public function scopeFilterTeam(Builder $query, array $args)
+    {
+        $query->when(isset($args['filter']) && isset($args['filter']['teamsIds']) && !empty($args['filter']['teamsIds']), function ($query) use ($args) {
+            $query->whereHas('users', function ($query) use ($args) {
+                $query->whereHas('teams', function ($query) use ($args) {
+                    $query->filterIds($args['filter']['teamsIds']);
+                });
+            });
         });
     }
 }

--- a/app/Models/Position.php
+++ b/app/Models/Position.php
@@ -64,7 +64,7 @@ class Position extends Model
         return $query;
     }
 
-    public function scopeFilterName(Builder $query, String $search)
+    public function scopeFilterName(Builder $query, string $search)
     {
         $query->when(isset($search), function ($query) use ($search) {
             $query->where('name', 'like', $search);

--- a/app/Models/Position.php
+++ b/app/Models/Position.php
@@ -79,12 +79,18 @@ class Position extends Model
 
     public function scopeFilterTeam(Builder $query, array $args)
     {
-        $query->when(isset($args['filter']) && isset($args['filter']['teamsIds']) && !empty($args['filter']['teamsIds']), function ($query) use ($args) {
-            $query->whereHas('users', function ($query) use ($args) {
-                $query->whereHas('teams', function ($query) use ($args) {
-                    $query->filterIds($args['filter']['teamsIds']);
+        $query->when(
+            isset($args['filter']) &&
+            isset($args['filter']['teamsIds']) &&
+            !empty($args['filter']['teamsIds']
+            ),
+            function ($query) use ($args) {
+                $query->whereHas('users', function ($query) use ($args) {
+                    $query->whereHas('teams', function ($query) use ($args) {
+                        $query->filterIds($args['filter']['teamsIds']);
+                    });
                 });
-            });
-        });
+            }
+        );
     }
 }

--- a/app/Models/Position.php
+++ b/app/Models/Position.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -46,5 +47,29 @@ class Position extends Model
                 ]
             )
             ->dontSubmitEmptyLogs();
+    }
+
+    public function list(array $args)
+    {
+        return $this
+            ->filterSearch($args);
+    }
+
+    public function scopeFilterSearch(Builder $query, array $args)
+    {
+        $query->when(isset($args['filter']) && isset($args['filter']['search']), function ($query) use ($args) {
+            $query->filterName($args['filter']['search']);
+        });
+
+        return $query;
+    }
+
+    public function scopeFilterName(Builder $query, String $search)
+    {
+        $query->when(isset($search), function ($query) use ($search) {
+            $query->where('name', 'like', $search);
+        });
+
+        return $query;
     }
 }

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -96,12 +96,17 @@ class Team extends Model
 
     public function scopeFilterPosition(Builder $query, array $args)
     {
-        $query->when(isset($args['filter']) && isset($args['filter']['positionsIds']) && !empty($args['filter']['positionsIds']), function ($query) use ($args) {
-            $query->whereHas('players', function ($query) use ($args) {
-                $query->whereHas('positions', function ($query) use ($args) {
-                    $query->filterIds($args['filter']['positionsIds']);
+        $query->when(
+            isset($args['filter']) &&
+            isset($args['filter']['positionsIds']) &&
+            !empty($args['filter']['positionsIds']),
+            function ($query) use ($args) {
+                $query->whereHas('players', function ($query) use ($args) {
+                    $query->whereHas('positions', function ($query) use ($args) {
+                        $query->filterIds($args['filter']['positionsIds']);
+                    });
                 });
-            });
-        });
+            }
+        );
     }
 }

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -63,5 +64,29 @@ class Team extends Model
                 ]
             )
             ->dontSubmitEmptyLogs();
+    }
+
+    public function list(array $args)
+    {
+        return $this
+            ->filterSearch($args);
+    }
+
+    public function scopeFilterSearch(Builder $query, array $args)
+    {
+        $query->when(isset($args['filter']) && isset($args['filter']['search']), function ($query) use ($args) {
+            $query->filterName($args['filter']['search']);
+        });
+
+        return $query;
+    }
+
+    public function scopeFilterName(Builder $query, String $search)
+    {
+        $query->when(isset($search), function ($query) use ($search) {
+            $query->where('name', 'like', $search);
+        });
+
+        return $query;
     }
 }

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -69,7 +69,8 @@ class Team extends Model
     public function list(array $args)
     {
         return $this
-            ->filterSearch($args);
+            ->filterSearch($args)
+            ->filterPosition($args);
     }
 
     public function scopeFilterSearch(Builder $query, array $args)
@@ -90,6 +91,17 @@ class Team extends Model
     {
         $query->when(isset($ids) && !empty($ids), function ($query) use ($ids) {
             $query->whereIn('teams.id', $ids);
+        });
+    }
+
+    public function scopeFilterPosition(Builder $query, array $args)
+    {
+        $query->when(isset($args['filter']) && isset($args['filter']['positionsIds']) && !empty($args['filter']['positionsIds']), function ($query) use ($args) {
+            $query->whereHas('players', function ($query) use ($args) {
+                $query->whereHas('positions', function ($query) use ($args) {
+                    $query->filterIds($args['filter']['position']);
+                });
+            });
         });
     }
 }

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -99,7 +99,7 @@ class Team extends Model
         $query->when(isset($args['filter']) && isset($args['filter']['positionsIds']) && !empty($args['filter']['positionsIds']), function ($query) use ($args) {
             $query->whereHas('players', function ($query) use ($args) {
                 $query->whereHas('positions', function ($query) use ($args) {
-                    $query->filterIds($args['filter']['position']);
+                    $query->filterIds($args['filter']['positionsIds']);
                 });
             });
         });

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -81,7 +81,7 @@ class Team extends Model
         return $query;
     }
 
-    public function scopeFilterName(Builder $query, String $search)
+    public function scopeFilterName(Builder $query, string $search)
     {
         $query->when(isset($search), function ($query) use ($search) {
             $query->where('name', 'like', $search);

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -77,16 +77,19 @@ class Team extends Model
         $query->when(isset($args['filter']) && isset($args['filter']['search']), function ($query) use ($args) {
             $query->filterName($args['filter']['search']);
         });
-
-        return $query;
     }
 
     public function scopeFilterName(Builder $query, string $search)
     {
         $query->when(isset($search), function ($query) use ($search) {
-            $query->where('name', 'like', $search);
+            $query->where('teams.name', 'like', $search);
         });
+    }
 
-        return $query;
+    public function scopeFilterIds(Builder $query, array $ids)
+    {
+        $query->when(isset($ids) && !empty($ids), function ($query) use ($ids) {
+            $query->whereIn('teams.id', $ids);
+        });
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Foundation\Auth\User as Authenticatable;
@@ -195,5 +196,95 @@ class User extends Authenticatable implements HasApiTokensContract
                 }
             }
         }
+    }
+
+    public function list(array $args)
+    {
+        return $this
+            ->filterSearch($args);
+    }
+
+    public function scopeFilterSearch(Builder $query, array $args)
+    {
+        $query->when(isset($args['filter']) && isset($args['filter']['search']), function ($query) use ($args) {
+            $query
+                ->filterName($args['filter']['search'])
+                ->orWhere(function ($query) use ($args) {
+                    $query
+                        ->filterEmail($args['filter']['search'])
+                        ->filterPhone($args['filter']['search'])
+                        ->filterCPF($args['filter']['search'])
+                        ->filterRG($args['filter']['search'])
+                        ->filterPosition($args['filter']['search'])
+                        ->filterTeam($args['filter']['search']);
+                });
+        });
+
+    }
+
+    public function scopeFilterName(Builder $query, string $search)
+    {
+        $query->when(isset($search), function ($query) use ($search) {
+            $query->where('name', 'like', $search);
+        });
+
+    }
+
+    public function scopeFilterEmail(Builder $query, string $search)
+    {
+        $query->when(isset($search), function ($query) use ($search) {
+            $query->where('email', 'like', $search);
+        });
+
+    }
+
+    public function scopeFilterCPF(Builder $query, string $search)
+    {
+        $query->when(isset($search), function ($query) use ($search) {
+            $query->orWhereHas('information', function ($query) use ($search) {
+                $query->filterCPF($search);
+            });
+        });
+
+    }
+
+    public function scopeFilterRG(Builder $query, string $search)
+    {
+        $query->when(isset($search), function ($query) use ($search) {
+            $query->orWhereHas('information', function ($query) use ($search) {
+                $query->filterRG($search);
+            });
+        });
+
+    }
+
+    public function scopeFilterPhone(Builder $query, string $search)
+    {
+        $query->when(isset($search), function ($query) use ($search) {
+            $query->orWhereHas('information', function ($query) use ($search) {
+                $query->filterPhone($search);
+            });
+        });
+
+    }
+
+    public function scopeFilterPosition(Builder $query, string $search)
+    {
+        $query->when(isset($search), function ($query) use ($search) {
+            $query->orWhereHas('positions', function ($query) use ($search) {
+                $query->filterName($search);
+            });
+        });
+
+    }
+
+    public function scopeFilterTeam(Builder $query, string $search)
+    {
+        $query->when(isset($search), function ($query) use ($search) {
+            $query->orWhereHas('teams', function ($query) use ($search) {
+                $query->filterName($search);
+            });
+        });
+
     }
 }

--- a/app/Models/UserInformation.php
+++ b/app/Models/UserInformation.php
@@ -26,21 +26,21 @@ class UserInformation extends Model
     public function scopeFilterCPF(Builder $query, string $cpf)
     {
         $query->when(isset($cpf), function ($query) use ($cpf) {
-            $query->where('cpf', 'like', $cpf);
+            $query->where('user_information.cpf', 'like', $cpf);
         });
     }
 
     public function scopeFilterRG(Builder $query, string $rg)
     {
         $query->when(isset($rg), function ($query) use ($rg) {
-            $query->where('rg', 'like', $rg);
+            $query->where('user_information.rg', 'like', $rg);
         });
     }
 
     public function scopeFilterPhone(Builder $query, string $phone)
     {
         $query->when(isset($phone), function ($query) use ($phone) {
-            $query->where('phone', 'like', $phone);
+            $query->where('user_information.phone', 'like', $phone);
         });
     }
 }

--- a/app/Models/UserInformation.php
+++ b/app/Models/UserInformation.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -20,5 +21,26 @@ class UserInformation extends Model
     public function user()
     {
         return $this->belongsTo(User::class);
+    }
+
+    public function scopeFilterCPF(Builder $query, string $cpf)
+    {
+        $query->when(isset($cpf), function ($query) use ($cpf) {
+            $query->where('cpf', 'like', $cpf);
+        });
+    }
+
+    public function scopeFilterRG(Builder $query, string $rg)
+    {
+        $query->when(isset($rg), function ($query) use ($rg) {
+            $query->where('rg', 'like', $rg);
+        });
+    }
+
+    public function scopeFilterPhone(Builder $query, string $phone)
+    {
+        $query->when(isset($phone), function ($query) use ($phone) {
+            $query->where('phone', 'like', $phone);
+        });
     }
 }

--- a/graphql/position/PositionQuery.graphql
+++ b/graphql/position/PositionQuery.graphql
@@ -12,7 +12,7 @@ extend type Query @guard {
 
     "List multiple positions."
     positions (
-        filter: PositionSearchType
+        filter: PositionSearchInput
     ): [Position!]! 
         @paginate(defaultCount: 10, maxCount: 100, builder: "App\\GraphQL\\Queries\\PositionQuery@list")
         @can(ability: "view", resolved: true)

--- a/graphql/position/PositionQuery.graphql
+++ b/graphql/position/PositionQuery.graphql
@@ -12,13 +12,8 @@ extend type Query @guard {
 
     "List multiple positions."
     positions (
-        "Filters by name. Accepts SQL LIKE wildcards `%` and `_`."
-        name: String @where(operator: "like")
-        
-        "Filters by the position's user_id."
-        user_id: Int @where(operator: "eq", field: "user_id")
-
+        filter: PositionSearchType
     ): [Position!]! 
-        @paginate(defaultCount: 10, maxCount: 100)
+        @paginate(defaultCount: 10, maxCount: 100, builder: "App\\GraphQL\\Queries\\PositionQuery@list")
         @can(ability: "view", resolved: true)
 }

--- a/graphql/position/PositionQuery.graphql
+++ b/graphql/position/PositionQuery.graphql
@@ -12,6 +12,7 @@ extend type Query @guard {
 
     "List multiple positions."
     positions (
+        "Specific filter search positions."
         filter: PositionSearchInput
     ): [Position!]! 
         @paginate(defaultCount: 10, maxCount: 100, builder: "App\\GraphQL\\Queries\\PositionQuery@list")

--- a/graphql/position/PositionSearchInput.graphql
+++ b/graphql/position/PositionSearchInput.graphql
@@ -3,4 +3,7 @@ input PositionSearchInput {
 
     "String to search for in positions name"
     search: String
+
+    "Filter by team ids"
+    teamsIds: [Int]
 }

--- a/graphql/position/PositionSearchInput.graphql
+++ b/graphql/position/PositionSearchInput.graphql
@@ -1,6 +1,6 @@
 "PositionSearchType"
 input PositionSearchInput {
 
-    "String to search for in position name"
+    "String to search for in positions name"
     search: String
 }

--- a/graphql/position/PositionSearchInput.graphql
+++ b/graphql/position/PositionSearchInput.graphql
@@ -1,5 +1,5 @@
 "PositionSearchType"
-input PositionSearchType {
+input PositionSearchInput {
 
     "String to search for in position name"
     search: String

--- a/graphql/position/PositionSearchType.graphql
+++ b/graphql/position/PositionSearchType.graphql
@@ -1,0 +1,6 @@
+"PositionSearchType"
+input PositionSearchType {
+
+    "String to search for in position name"
+    search: String
+}

--- a/graphql/team/TeamQuery.graphql
+++ b/graphql/team/TeamQuery.graphql
@@ -10,6 +10,7 @@ extend type Query @guard {
 
     "List multiple teams."
     teams(
+        "Specific filter search teams."
         filter: TeamSearchInput
     ): [Team!]!
         @paginate(defaultCount: 10, maxCount: 100, builder: "App\\GraphQL\\Queries\\TeamQuery@list")

--- a/graphql/team/TeamQuery.graphql
+++ b/graphql/team/TeamQuery.graphql
@@ -10,13 +10,8 @@ extend type Query @guard {
 
     "List multiple teams."
     teams(
-        "Filters by name. Accepts SQL LIKE wildcards `%` and `_`."
-        name: String @where(operator: "like")
-        
-        "Filters by the team's user_id."
-        user_id: Int @where(operator: "eq", field: "user_id")
-
+        filter: TeamSearchInput
     ): [Team!]!
+        @paginate(defaultCount: 10, maxCount: 100, builder: "App\\GraphQL\\Queries\\TeamQuery@list")
         @can(ability: "view", resolved: true)
-        @paginate(defaultCount: 10, maxCount: 100)
 }

--- a/graphql/team/TeamSearchInput.graphql
+++ b/graphql/team/TeamSearchInput.graphql
@@ -1,6 +1,6 @@
 "TeamSearchType"
 input TeamSearchInput {
 
-    "String to search for in team name"
+    "String to search for in teams name"
     search: String
 }

--- a/graphql/team/TeamSearchInput.graphql
+++ b/graphql/team/TeamSearchInput.graphql
@@ -3,4 +3,7 @@ input TeamSearchInput {
 
     "String to search for in teams name"
     search: String
+
+    "Filter by position ids"
+    positionsIds: [Int]
 }

--- a/graphql/team/TeamSearchInput.graphql
+++ b/graphql/team/TeamSearchInput.graphql
@@ -1,0 +1,6 @@
+"TeamSearchType"
+input TeamSearchInput {
+
+    "String to search for in team name"
+    search: String
+}

--- a/graphql/user/UserQuery.graphql
+++ b/graphql/user/UserQuery.graphql
@@ -15,10 +15,11 @@ extend type Query @guard {
 
     "List multiple users."
     users(
-      "Filters by name. Accepts SQL LIKE wildcards `%` and `_`."
-      name: String @where(operator: "like")
+        "Specific filter search users."
+        filter: UserSearchInput
+
     ): [User!]! 
+        @paginate(defaultCount: 10, maxCount: 100, builder: "App\\GraphQL\\Queries\\UserQuery@list")
         @can(ability: "view", resolved: true)
-        @paginate(defaultCount: 10)
 }
 

--- a/graphql/user/UserSearchInput.graphql
+++ b/graphql/user/UserSearchInput.graphql
@@ -1,7 +1,7 @@
-"TeamSearchType"
+"UserSearchInput"
 input UserSearchInput {
 
-    "String to search for in team name"
+    "String to search for in users name"
     search: String
 
     "Filter by positions ids"

--- a/graphql/user/UserSearchInput.graphql
+++ b/graphql/user/UserSearchInput.graphql
@@ -3,4 +3,10 @@ input UserSearchInput {
 
     "String to search for in team name"
     search: String
+
+    "Filter by positions ids"
+    positionsIds: [Int]
+
+    "Filter by team ids"
+    teamsIds: [Int]
 }

--- a/graphql/user/UserSearchInput.graphql
+++ b/graphql/user/UserSearchInput.graphql
@@ -1,0 +1,6 @@
+"TeamSearchType"
+input UserSearchInput {
+
+    "String to search for in team name"
+    search: String
+}

--- a/tests/Feature/GraphQL/FundamentalTest.php
+++ b/tests/Feature/GraphQL/FundamentalTest.php
@@ -54,7 +54,6 @@ class FundamentalTest extends TestCase
         $response = $this->graphQL(
             'fundamentals',
             [
-                'name' => '%%',
                 'first' => 10,
                 'page' => 1,
             ],

--- a/tests/Feature/GraphQL/PositionTest.php
+++ b/tests/Feature/GraphQL/PositionTest.php
@@ -54,7 +54,6 @@ class PositionTest extends TestCase
         $response = $this->graphQL(
             'positions',
             [
-                'name' => '%%',
                 'first' => 10,
                 'page' => 1,
             ],

--- a/tests/Feature/GraphQL/RoleTest.php
+++ b/tests/Feature/GraphQL/RoleTest.php
@@ -61,7 +61,6 @@ class RoleTest extends TestCase
         $this->graphQL(
             'roles',
             [
-                'name' => '%%',
                 'first' => 10,
                 'page' => 1,
             ],

--- a/tests/Feature/GraphQL/SpecificFundamentalTest.php
+++ b/tests/Feature/GraphQL/SpecificFundamentalTest.php
@@ -55,7 +55,6 @@ class SpecificFundamentalTest extends TestCase
         $response = $this->graphQL(
             'specificFundamentals',
             [
-                'name' => '%%',
                 'first' => 10,
                 'page' => 1,
             ],

--- a/tests/Feature/GraphQL/TeamTest.php
+++ b/tests/Feature/GraphQL/TeamTest.php
@@ -56,7 +56,6 @@ class TeamTest extends TestCase
         $response = $this->graphQL(
             'teams',
             [
-                'name' => '%%',
                 'first' => 10,
                 'page' => 1,
             ],

--- a/tests/Feature/GraphQL/TrainingTest.php
+++ b/tests/Feature/GraphQL/TrainingTest.php
@@ -80,7 +80,6 @@ class TrainingTest extends TestCase
         $response = $this->graphQL(
             'trainings',
             [
-                'name' => '%%',
                 'first' => 10,
                 'page' => 1,
             ],

--- a/tests/Feature/GraphQL/UserTest.php
+++ b/tests/Feature/GraphQL/UserTest.php
@@ -61,7 +61,6 @@ class UserTest extends TestCase
         $response = $this->graphQL(
             'users',
             [
-                'name' => '%%',
                 'first' => 10,
                 'page' => 1,
             ],


### PR DESCRIPTION
### O que?

Filtros padrão da listagem de jogadores.

### Por quê?

Na listagem de jogadores existem os filtros de posição e de times. Para que se possa fazer a busca dos jogadores pelos times que eles estão relacionados.

### Como?

Com base no relacionamento do banco de dados, fazer os filtros de time e posição.

### Capturas de tela

![image](https://github.com/Zoren-Software/VoleiClub/assets/25940408/048390fb-6ca6-43ac-a5e1-f63fff554b11)


