### PR TITLE
Posições: Adicionado filtro para itens já relacionados em posições `ignoreIds`

### DIFF
--- a/app/Models/Position.php
+++ b/app/Models/Position.php
@@ -53,7 +53,15 @@ class Position extends Model
     {
         return $this
             ->filterSearch($args)
+            ->filterIgnores($args)
             ->filterTeam($args);
+    }
+
+    public function scopeFilterIgnores(Builder $query, array $args)
+    {
+        $query->when(isset($args['filter']) && isset($args['filter']['ignoreIds']), function ($query) use ($args) {
+            $query->whereNotIn('positions.id', $args['filter']['ignoreIds']);
+        });
     }
 
     public function scopeFilterSearch(Builder $query, array $args)

--- a/graphql/position/PositionSearchInput.graphql
+++ b/graphql/position/PositionSearchInput.graphql
@@ -6,4 +6,7 @@ input PositionSearchInput {
 
     "Filter by team ids"
     teamsIds: [Int]
+
+    "Ignore ids selected"
+    ignoreIds: [Int]
 }


### PR DESCRIPTION
### O que?

Adicionado opção no filtro `ignoreIds`.

### Por quê?

Para poder conseguir trazer resultados referentes ao que já foi selecionado.

### Como?

Na consulta de Posições foi adicionado essa opção de `ignoreIds` fazendo um whereNotIn para os itens que já foram selecionados.
