### PR TITLE
Times: Adicionado filtro para itens já relacionados em times

### DIFF
--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -70,7 +70,15 @@ class Team extends Model
     {
         return $this
             ->filterSearch($args)
+            ->filterIgnores($args)
             ->filterPosition($args);
+    }
+
+    public function scopeFilterIgnores(Builder $query, array $args)
+    {
+        $query->when(isset($args['filter']) && isset($args['filter']['ignoreIds']), function ($query) use ($args) {
+            $query->whereNotIn('teams.id', $args['filter']['ignoreIds']);
+        });
     }
 
     public function scopeFilterSearch(Builder $query, array $args)

--- a/graphql/team/TeamSearchInput.graphql
+++ b/graphql/team/TeamSearchInput.graphql
@@ -6,4 +6,7 @@ input TeamSearchInput {
 
     "Filter by position ids"
     positionsIds: [Int]
+
+    "Ignore ids selected"
+    ignoreIds: [Int]
 }


### PR DESCRIPTION
### O que?

Adicionado opção no filtro `ignoreIds`.

### Por quê?

Para poder conseguir trazer resultados referentes ao que já foi selecionado.

### Como?

Na consulta de Posições foi adicionado essa opção de `ignoreIds` fazendo um whereNotIn para os itens que já foram selecionados.
