### PR TITLE
Cargo: Ajustado consulta de roles para o sistema

### DIFF
--- a/app/GraphQL/Queries/RoleQuery.php
+++ b/app/GraphQL/Queries/RoleQuery.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\GraphQL\Queries;
+
+use App\Models\Role;
+
+class RoleQuery
+{
+    /**
+     * @codeCoverageIgnore
+     *
+     * @param  null  $_
+     * @param  array{}  $args
+     */
+    public function list($_, array $args)
+    {
+        $role = new Role();
+
+        return $role->list($args);
+    }
+}

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -53,4 +53,24 @@ class Role extends SpatieRole
                 );
         });
     }
+
+    public function list(array $args)
+    {
+        return $this
+            ->filterSearch($args);
+    }
+
+    public function scopeFilterSearch(Builder $query, array $args)
+    {
+        $query->when(isset($args['filter']) && isset($args['filter']['search']), function ($query) use ($args) {
+            $query->filterName($args['filter']['search']);
+        });
+    }
+
+    public function scopeFilterName(Builder $query, string $search)
+    {
+        $query->when(isset($search), function ($query) use ($search) {
+            $query->where('roles.name', 'like', $search);
+        });
+    }
 }

--- a/graphql/role/RoleQuery.graphql
+++ b/graphql/role/RoleQuery.graphql
@@ -7,7 +7,8 @@ extend type Query @guard {
 
     "List multiple roles."
     roles (
-      "Filters by name. Accepts SQL LIKE wildcards `%` and `_`."
-      name: String @where(operator: "like")
-    ): [Role!]! @paginate(defaultCount: 10)
+      "Specific filter search roles."
+      filter: RoleSearchInput
+    ): [Role!]! 
+        @paginate(defaultCount: 10, maxCount: 100, builder: "App\\GraphQL\\Queries\\RoleQuery@list")
 }

--- a/graphql/role/RoleSearchInput.graphql
+++ b/graphql/role/RoleSearchInput.graphql
@@ -1,0 +1,6 @@
+"TeamSearchType"
+input RoleSearchInput {
+
+    "String to search for in roles name"
+    search: String
+}


### PR DESCRIPTION
### O que?

Padronizado o end-point de pesquisa, para ter o parâmetro `filter`.

### Por quê?

Padronização de rotas no sistema.

### Como?

Adicionado nova tipagem `RoleSearchInput` adicionando o parâmetro  `filter` com o argumento enviado via `search`.
