### PR TITLE
Cargos: Adicionado filtro para itens já relacionados em cargos

### DIFF
--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -57,7 +57,15 @@ class Role extends SpatieRole
     public function list(array $args)
     {
         return $this
-            ->filterSearch($args);
+            ->filterSearch($args)
+            ->filterIgnores($args);
+    }
+
+    public function scopeFilterIgnores(Builder $query, array $args)
+    {
+        $query->when(isset($args['filter']) && isset($args['filter']['ignoreIds']), function ($query) use ($args) {
+            $query->whereNotIn('roles.id', $args['filter']['ignoreIds']);
+        });
     }
 
     public function scopeFilterSearch(Builder $query, array $args)

--- a/graphql/role/RoleSearchInput.graphql
+++ b/graphql/role/RoleSearchInput.graphql
@@ -3,4 +3,7 @@ input RoleSearchInput {
 
     "String to search for in roles name"
     search: String
+
+    "Ignore ids selected"
+    ignoreIds: [Int]
 }


### PR DESCRIPTION
### O que?

Adicionado opção no filtro `ignoreIds`.

### Por quê?

Para poder conseguir trazer resultados referentes ao que já foi selecionado.

### Como?

Na consulta de Cargos foi adicionado essa opção de `ignoreIds` fazendo um whereNotIn para os itens que já foram selecionados.
