### PR TITLE
Usuário: Criando validação do nome para cadastro do usuário

### DIFF
--- a/app/GraphQL/Validators/Mutation/UserCreateValidator.php
+++ b/app/GraphQL/Validators/Mutation/UserCreateValidator.php
@@ -15,6 +15,10 @@ class UserCreateValidator extends Validator
     public function rules(): array
     {
         return [
+            'name' => [
+                'required',
+                'min:3',
+            ],
             'password' => [
                 'required',
                 'min:6',
@@ -44,6 +48,8 @@ class UserCreateValidator extends Validator
     public function messages(): array
     {
         return [
+            'name.required' => trans('UserCreate.name_required'),
+            'name.min' => trans('UserCreate.name_min_3'),
             'password.required' => trans('UserCreate.password_required'),
             'password.min' => trans('UserCreate.password_min_6'),
             'email.required' => trans('UserCreate.email_required'),

--- a/app/GraphQL/Validators/Mutation/UserEditValidator.php
+++ b/app/GraphQL/Validators/Mutation/UserEditValidator.php
@@ -15,6 +15,10 @@ final class UserEditValidator extends Validator
     public function rules(): array
     {
         return [
+            'name' => [
+                'required',
+                'min:3',
+            ],
             'password' => [
                 'required',
                 'min:6',
@@ -44,6 +48,8 @@ final class UserEditValidator extends Validator
     public function messages(): array
     {
         return [
+            'name.required' => trans('UserEdit.name_required'),
+            'name.min' => trans('UserEdit.name_min_3'),
             'password.required' => trans('UserEdit.password_required'),
             'password.min' => trans('UserEdit.password_min_6'),
             'email.required' => trans('UserEdit.email_required'),

--- a/lang/en/UserCreate.php
+++ b/lang/en/UserCreate.php
@@ -13,12 +13,14 @@ return [
     |
     */
 
+    'name_required' => 'The name field is required.',
+    'name_min_3' => 'The name field must be at least 3 characters long.',
     'email_is_valid' => 'The email field must be a valid email address.',
     'email_required' => 'The email field is required.',
     'email_unique' => 'This email has already been registered.',
     'password_min_6' => 'The password must be at least 6 characters long.',
     'password_required' => 'The password field is required.',
-    'role_id_required' => 'The roleId field is required.',
+    'role_id_required' => 'The permission field is required.',
     'cpf_unique' => 'This CPF has already been registered.',
     'rg_unique' => 'This RG has already been registered.',
 ];

--- a/lang/en/UserEdit.php
+++ b/lang/en/UserEdit.php
@@ -13,12 +13,14 @@ return [
     |
     */
 
+    'name_required' => 'The name field is required.',
+    'name_min_3' => 'The name field must be at least 3 characters long.',
     'email_is_valid' => 'The email field must be a valid email address.',
     'email_required' => 'The email field is required.',
     'email_unique' => 'This email has already been registered.',
     'password_min_6' => 'The password must be at least 6 characters long.',
     'password_required' => 'The password field is required.',
-    'role_id_required' => 'The roleId field is required.',
+    'role_id_required' => 'The permission field is required.',
     'cpf_unique' => 'This CPF has already been registered.',
     'rg_unique' => 'This RG has already been registered.',
 ];

--- a/lang/pt-br/UserCreate.php
+++ b/lang/pt-br/UserCreate.php
@@ -13,12 +13,14 @@ return [
     |
     */
 
+    'name_required' => 'O campo nome é obrigatório.',
+    'name_min_3' => 'O campo nome deve ter no mínimo 3 caracteres.',
     'email_is_valid' => 'O campo e-mail deve ser um e-mail válido.',
     'email_required' => 'O campo e-mail é obrigatório.',
     'email_unique' => 'Este e-mail já foi registrado.',
     'password_min_6' => 'A senha precisa ter no mínimo 6 caracteres.',
     'password_required' => 'O campo senha é obrigatório.',
-    'role_id_required' => 'O campo roleId é obrigatório.',
+    'role_id_required' => 'O campo permissão é obrigatório.',
     'cpf_unique' => 'Este CPF já foi registrado.',
     'rg_unique' => 'Este RG já foi registrado.',
 ];

--- a/lang/pt-br/UserEdit.php
+++ b/lang/pt-br/UserEdit.php
@@ -13,12 +13,14 @@ return [
     |
     */
 
+    'name_required' => 'O campo nome é obrigatório.',
+    'name_min_3' => 'O campo nome deve ter no mínimo 3 caracteres.',
     'email_is_valid' => 'O campo e-mail deve ser um e-mail válido.',
     'email_required' => 'O campo e-mail é obrigatório.',
     'email_unique' => 'Este e-mail já foi registrado.',
     'password_min_6' => 'A senha precisa ter no mínimo 6 caracteres.',
     'password_required' => 'O campo senha é obrigatório.',
-    'role_id_required' => 'O campo roleId é obrigatório.',
+    'role_id_required' => 'O campo permissão é obrigatório.',
     'cpf_unique' => 'Este CPF já foi registrado.',
     'rg_unique' => 'Este RG já foi registrado.',
 ];

--- a/tests/Feature/GraphQL/UserTest.php
+++ b/tests/Feature/GraphQL/UserTest.php
@@ -213,8 +213,6 @@ class UserTest extends TestCase
     ) {
         $this->setPermissions($hasPermission);
 
-        $faker = Faker::create();
-
         if ($hasTeam) {
             $team = Team::factory()->create();
             $parameters['teamId'] = $team->id;

--- a/tests/Feature/GraphQL/UserTest.php
+++ b/tests/Feature/GraphQL/UserTest.php
@@ -220,7 +220,9 @@ class UserTest extends TestCase
             $parameters['teamId'] = $team->id;
         }
 
-        $parameters['name'] = $faker->name;
+        if($parameters['name'] == null) {
+            $parameters['name'] = ' ';
+        }
 
         $response = $this->graphQL(
             'userCreate',
@@ -446,6 +448,7 @@ class UserTest extends TestCase
             ],
             'no text password, expected error' => [
                 [
+                    'name' => $faker->name,
                     'password' => ' ',
                     'email' => $faker->email,
                     'roleId' => [2],
@@ -485,6 +488,38 @@ class UserTest extends TestCase
                 ],
                 'type_message_error' => 'email',
                 'expected_message' => 'UserCreate.email_required',
+                'expected' => [
+                    'errors' => self::$errors,
+                    'data' => $userCreate,
+                ],
+                'hasTeam' => false,
+                'hasPermission' => true,
+            ],
+            'name field is required, expected error' => [
+                [
+                    'name' => null,
+                    'password' => $password,
+                    'roleId' => [2],
+                    'email' => $faker->email,
+                ],
+                'type_message_error' => 'name',
+                'expected_message' => 'UserCreate.name_required',
+                'expected' => [
+                    'errors' => self::$errors,
+                    'data' => $userCreate,
+                ],
+                'hasTeam' => false,
+                'hasPermission' => true,
+            ],
+            'name field is min 3 characters, expected error' => [
+                [
+                    'name' => 'Th',
+                    'password' => $password,
+                    'roleId' => [2],
+                    'email' => $faker->email,
+                ],
+                'type_message_error' => 'name',
+                'expected_message' => 'UserCreate.name_min_3',
                 'expected' => [
                     'errors' => self::$errors,
                     'data' => $userCreate,
@@ -828,6 +863,38 @@ class UserTest extends TestCase
                 ],
                 'type_message_error' => 'email',
                 'expected_message' => 'UserEdit.email_required',
+                'expected' => [
+                    'errors' => self::$errors,
+                    'data' => $userEdit,
+                ],
+                'hasTeam' => false,
+                'hasPermission' => true,
+            ],
+            'name field is required, expected error' => [
+                [
+                    'name' => ' ',
+                    'password' => $password,
+                    'email' => $faker->email,
+                    'roleId' => [2],
+                ],
+                'type_message_error' => 'name',
+                'expected_message' => 'UserEdit.name_required',
+                'expected' => [
+                    'errors' => self::$errors,
+                    'data' => $userEdit,
+                ],
+                'hasTeam' => false,
+                'hasPermission' => true,
+            ],
+            'name field is min 3 characters, expected error' => [
+                [
+                    'name' => 'Th',
+                    'password' => $password,
+                    'email' => $faker->email,
+                    'roleId' => [2],
+                ],
+                'type_message_error' => 'name',
+                'expected_message' => 'UserEdit.name_min_3',
                 'expected' => [
                     'errors' => self::$errors,
                     'data' => $userEdit,


### PR DESCRIPTION
### O que?

Adicionado o campo `name` como obrigatório no cadastro do usuário. E ter ao menos 3 caracteres.

### Por quê?

Este campo deve ser obrigatório.

### Como?

Adicionado validação para o GraphQL
