### PR TITLE
Usuário: Saída do relacionamento de roles dos usuários

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -221,7 +221,6 @@ class User extends Authenticatable implements HasApiTokensContract
                         ->filterTeamName($args['filter']['search']);
                 });
         });
-
     }
 
     public function scopeFilterName(Builder $query, string $search)
@@ -229,7 +228,6 @@ class User extends Authenticatable implements HasApiTokensContract
         $query->when(isset($search), function ($query) use ($search) {
             $query->where('users.name', 'like', $search);
         });
-
     }
 
     public function scopeFilterEmail(Builder $query, string $search)
@@ -237,7 +235,6 @@ class User extends Authenticatable implements HasApiTokensContract
         $query->when(isset($search), function ($query) use ($search) {
             $query->where('users.email', 'like', $search);
         });
-
     }
 
     public function scopeFilterCPF(Builder $query, string $search)
@@ -247,7 +244,6 @@ class User extends Authenticatable implements HasApiTokensContract
                 $query->filterCPF($search);
             });
         });
-
     }
 
     public function scopeFilterRG(Builder $query, string $search)
@@ -257,7 +253,6 @@ class User extends Authenticatable implements HasApiTokensContract
                 $query->filterRG($search);
             });
         });
-
     }
 
     public function scopeFilterPhone(Builder $query, string $search)
@@ -267,7 +262,6 @@ class User extends Authenticatable implements HasApiTokensContract
                 $query->filterPhone($search);
             });
         });
-
     }
 
     public function scopeFilterPositionName(Builder $query, string $search)
@@ -277,7 +271,6 @@ class User extends Authenticatable implements HasApiTokensContract
                 $query->filterName($search);
             });
         });
-
     }
 
     public function scopeFilterTeamName(Builder $query, string $search)

--- a/graphql/user/UserQuery.graphql
+++ b/graphql/user/UserQuery.graphql
@@ -5,10 +5,7 @@ extend type Query @guard {
     "Find a single user by an identifying attribute."
     user(
       "Search by primary key."
-      id: ID @eq @rules(apply: ["prohibits:email", "required_without:email"])
-
-      "Search by email address."
-      email: String @eq @rules(apply: ["prohibits:id", "required_without:id", "email"])
+      id: ID! @eq @rules(apply: ["prohibits:email", "required_without:email"])
     ): User 
         @can(ability: "view", resolved: true)
         @find

--- a/graphql/user/UserType.graphql
+++ b/graphql/user/UserType.graphql
@@ -15,6 +15,9 @@ type User {
     "Teams."
     teams: [Team] @belongsToMany(relation: "teams")
 
+    "Roles."
+    roles: [Role] @belongsToMany(relation: "roles")
+
     "Information."
     information: UserInformation @hasOne(relation: "information")
 


### PR DESCRIPTION
### O que?

Adicionado relacionamento de roles dos usuários

### Por quê?

Para expor essa informação nas saídas da API GraphQL

### Como?

Apenas ajustado o type GraphQL para mostrar os resultados da saída
