### PR TITLE
Usuário: Ajustado validações para CPF e RG para permitir campos null sem acusar erro em validação sobre repetição

### DIFF
--- a/app/GraphQL/Validators/Mutation/UserCreateValidator.php
+++ b/app/GraphQL/Validators/Mutation/UserCreateValidator.php
@@ -34,9 +34,11 @@ class UserCreateValidator extends Validator
                 new PermissionAssignment(),
             ],
             'cpf' => [
+                'nullable',
                 'unique:user_information,cpf',
             ],
             'rg' => [
+                'nullable',
                 'unique:user_information,rg',
             ],
         ];

--- a/app/GraphQL/Validators/Mutation/UserEditValidator.php
+++ b/app/GraphQL/Validators/Mutation/UserEditValidator.php
@@ -34,9 +34,11 @@ final class UserEditValidator extends Validator
                 new PermissionAssignment(),
             ],
             'cpf' => [
+                'nullable',
                 'unique:user_information,cpf,' . $this->arg('id'),
             ],
             'rg' => [
+                'nullable',
                 'unique:user_information,rg,' . $this->arg('id'),
             ],
         ];

--- a/database/migrations/tenant/base/2014_10_12_010000_create_users_informations_table.php
+++ b/database/migrations/tenant/base/2014_10_12_010000_create_users_informations_table.php
@@ -16,9 +16,9 @@ class CreateUsersInformationsTable extends Migration
         Schema::create('user_information', function (Blueprint $table) {
             $table->id();
             $table->foreignId('user_id')->constrained()->onDelete('cascade');
-            $table->string('cpf');
-            $table->string('phone');
-            $table->string('rg');
+            $table->string('cpf')->nullable();
+            $table->string('phone')->nullable();
+            $table->string('rg')->nullable();
             $table->timestamps();
             $table->softDeletes();
 

--- a/graphql/user/UserInformationType.graphql
+++ b/graphql/user/UserInformationType.graphql
@@ -10,13 +10,13 @@ type UserInformation {
     user: User @belongsTo(relation: "user")
 
     "CPF."
-    cpf: String!
+    cpf: String
 
     "RG."
-    rg: String!
+    rg: String
 
     "Phone number."
-    phone: String!
+    phone: String
 
     "Date created. A datetime string with format `Y-m-d H:i:s`, e.g. `2018-05-23 13:43:32`."
     createdAt: DateTime! @rename(attribute: "created_at")


### PR DESCRIPTION
### O que?

Ajustado validação dos campos nulos para permitir os registros caso estes valores não sejam feitos para o usuário.

### Por quê?

No caso de existir 2 jogadores com CPF ou RG nulo estava acusando que já existia.

### Como?

Permitido fazer o registro de campos null no banco de dados, e ajustado a validação feita pelo validator

