### PR TITLE
Usuário: Adicionando validação para deletar usuários e pesquisa de CPF, RG e Phone

### DIFF
--- a/app/GraphQL/Validators/Mutation/UserCreateValidator.php
+++ b/app/GraphQL/Validators/Mutation/UserCreateValidator.php
@@ -59,7 +59,7 @@ class UserCreateValidator extends Validator
             'email.email' => trans('UserCreate.email_is_valid'),
             'email.unique' => trans('UserCreate.email_unique'),
             'cpf.unique' => trans('UserCreate.cpf_unique'),
-            'rg.unique' => trans('UserCreate.rg_unique')
+            'rg.unique' => trans('UserCreate.rg_unique'),
         ];
     }
 }

--- a/app/GraphQL/Validators/Mutation/UserDeleteValidator.php
+++ b/app/GraphQL/Validators/Mutation/UserDeleteValidator.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\GraphQL\Validators\Mutation;
+
+use App\Rules\CannotDeleteOwnAccount;
+use Nuwave\Lighthouse\Validation\Validator;
+
+final class UserDeleteValidator extends Validator
+{
+    /**
+     * Return the validation rules.
+     *
+     * @return array<string, array<mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'id' => [
+                'required',
+                'exists:users,id',
+                new CannotDeleteOwnAccount($this->arg('id')),
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'id.required' => trans('UserDelete.ids_required'),
+            'id.exists' => trans('UserDelete.ids_exists'),
+        ];
+    }
+}

--- a/app/GraphQL/Validators/Mutation/UserEditValidator.php
+++ b/app/GraphQL/Validators/Mutation/UserEditValidator.php
@@ -2,9 +2,9 @@
 
 namespace App\GraphQL\Validators\Mutation;
 
+use App\Rules\OwnsPassword;
 use App\Rules\PermissionAssignment;
 use Illuminate\Validation\Rule;
-use App\Rules\OwnsPassword;
 use Nuwave\Lighthouse\Validation\Validator;
 
 final class UserEditValidator extends Validator

--- a/app/GraphQL/Validators/Mutation/UserEditValidator.php
+++ b/app/GraphQL/Validators/Mutation/UserEditValidator.php
@@ -65,13 +65,4 @@ final class UserEditValidator extends Validator
             'rg.unique' => trans('UserEdit.rg_unique'),
         ];
     }
-
-    public function withValidator($validator)
-    {
-        $validator->after(function ($validator) {
-            if ($this->arg('id') !== auth()->id()) {
-                $validator->errors()->add('password', 'Você não tem permissão para alterar a senha deste usuário.');
-            }
-        });
-    }
 }

--- a/app/GraphQL/Validators/Mutation/UserEditValidator.php
+++ b/app/GraphQL/Validators/Mutation/UserEditValidator.php
@@ -69,7 +69,6 @@ final class UserEditValidator extends Validator
     public function withValidator($validator)
     {
         $validator->after(function ($validator) {
-            dd(0);
             if ($this->arg('id') !== auth()->id()) {
                 $validator->errors()->add('password', 'Você não tem permissão para alterar a senha deste usuário.');
             }

--- a/app/Http/Middleware/SessionTimeoutMiddleware.php
+++ b/app/Http/Middleware/SessionTimeoutMiddleware.php
@@ -9,7 +9,9 @@ class SessionTimeoutMiddleware
 {
     /**
      * Handle an incoming request.
+     *
      * @codeCoverageIgnore
+     *
      * @param  \Closure(\Illuminate\Http\Request): (\Illuminate\Http\Response|\Illuminate\Http\RedirectResponse)  $next
      * @return \Illuminate\Http\Response|\Illuminate\Http\RedirectResponse
      */

--- a/app/Models/Position.php
+++ b/app/Models/Position.php
@@ -80,7 +80,7 @@ class Position extends Model
 
     public function scopeFilterIds(Builder $query, array $ids)
     {
-        $query->when(isset($ids) && !empty($ids), function ($query) use ($ids) {
+        $query->when(isset($ids) && ! empty($ids), function ($query) use ($ids) {
             $query->whereIn('positions.id', $ids);
         });
     }
@@ -90,7 +90,7 @@ class Position extends Model
         $query->when(
             isset($args['filter']) &&
             isset($args['filter']['teamsIds']) &&
-            !empty($args['filter']['teamsIds']
+            ! empty($args['filter']['teamsIds']
             ),
             function ($query) use ($args) {
                 $query->whereHas('users', function ($query) use ($args) {

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -97,7 +97,7 @@ class Team extends Model
 
     public function scopeFilterIds(Builder $query, array $ids)
     {
-        $query->when(isset($ids) && !empty($ids), function ($query) use ($ids) {
+        $query->when(isset($ids) && ! empty($ids), function ($query) use ($ids) {
             $query->whereIn('teams.id', $ids);
         });
     }
@@ -107,7 +107,7 @@ class Team extends Model
         $query->when(
             isset($args['filter']) &&
             isset($args['filter']['positionsIds']) &&
-            !empty($args['filter']['positionsIds']),
+            ! empty($args['filter']['positionsIds']),
             function ($query) use ($args) {
                 $query->whereHas('players', function ($query) use ($args) {
                     $query->whereHas('positions', function ($query) use ($args) {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -9,13 +9,12 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Facades\Hash;
-use App\Models\Role;
 use Laravel\Sanctum\Contracts\HasApiTokens as HasApiTokensContract;
 use Laravel\Sanctum\HasApiTokens;
 use Spatie\Activitylog\LogOptions;
 use Spatie\Activitylog\Traits\LogsActivity;
-use Spatie\Permission\Traits\HasRoles;
 use Spatie\Permission\PermissionRegistrar;
+use Spatie\Permission\Traits\HasRoles;
 
 class User extends Authenticatable implements HasApiTokensContract
 {
@@ -79,7 +78,7 @@ class User extends Authenticatable implements HasApiTokensContract
 
         return $relation->wherePivot(PermissionRegistrar::$teamsKey, getPermissionsTeamId())
             ->where(function ($q) {
-                $teamField = config('permission.table_names.roles').'.'.PermissionRegistrar::$teamsKey;
+                $teamField = config('permission.table_names.roles') . '.' . PermissionRegistrar::$teamsKey;
                 $q->whereNull($teamField)->orWhere($teamField, getPermissionsTeamId());
             });
     }
@@ -186,11 +185,9 @@ class User extends Authenticatable implements HasApiTokensContract
     }
 
     /**
-     *
      * @codeCoverageIgnore
      *
-     * @param mixed $args
-     *
+     * @param  mixed  $args
      * @return void
      */
     public function updateOrNewInformation($args)
@@ -209,8 +206,8 @@ class User extends Authenticatable implements HasApiTokensContract
             $attributes['rg'] = $args['rg'];
         }
 
-        if (!empty($attributes)) {
-            if (!$this->information) {
+        if (! empty($attributes)) {
+            if (! $this->information) {
                 $this->information = $this->information()->create($attributes);
             } else {
                 $this->information->fill($attributes);
@@ -311,7 +308,7 @@ class User extends Authenticatable implements HasApiTokensContract
         $query->when(
             isset($args['filter']) &&
             isset($args['filter']['positionsIds']) &&
-            !empty($args['filter']['positionsIds']),
+            ! empty($args['filter']['positionsIds']),
             function ($query) use ($args) {
                 $query->whereHas('positions', function ($query) use ($args) {
                     $query->filterIds($args['filter']['positionsIds']);
@@ -325,7 +322,7 @@ class User extends Authenticatable implements HasApiTokensContract
         $query->when(
             isset($args['filter']) &&
             isset($args['filter']['teamsIds']) &&
-            !empty($args['filter']['teamsIds']),
+            ! empty($args['filter']['teamsIds']),
             function ($query) use ($args) {
                 $query->whereHas('teams', function ($query) use ($args) {
                     $query->filterIds($args['filter']['teamsIds']);

--- a/app/Models/UserInformation.php
+++ b/app/Models/UserInformation.php
@@ -15,7 +15,7 @@ class UserInformation extends Model
     protected $fillable = [
         'cpf',
         'phone',
-        'rg'
+        'rg',
     ];
 
     public function user()

--- a/app/Models/UserInformation.php
+++ b/app/Models/UserInformation.php
@@ -25,22 +25,25 @@ class UserInformation extends Model
 
     public function scopeFilterCPF(Builder $query, string $cpf)
     {
-        $query->when(isset($cpf), function ($query) use ($cpf) {
-            $query->where('user_information.cpf', 'like', $cpf);
+        $cleanCpf = preg_replace('/\D/', '', $cpf);
+        $query->when(isset($cleanCpf), function ($query) use ($cleanCpf) {
+            $query->where('user_information.cpf', 'like', "%$cleanCpf%");
         });
     }
 
     public function scopeFilterRG(Builder $query, string $rg)
     {
-        $query->when(isset($rg), function ($query) use ($rg) {
-            $query->where('user_information.rg', 'like', $rg);
+        $cleanRg = preg_replace('/\D/', '', $rg);
+        $query->when(isset($cleanRg), function ($query) use ($cleanRg) {
+            $query->where('user_information.rg', 'like', "%$cleanRg%");
         });
     }
 
     public function scopeFilterPhone(Builder $query, string $phone)
     {
-        $query->when(isset($phone), function ($query) use ($phone) {
-            $query->where('user_information.phone', 'like', $phone);
+        $cleanPhone = preg_replace('/\D/', '', $phone);
+        $query->when(isset($cleanPhone), function ($query) use ($cleanPhone) {
+            $query->where('user_information.phone', 'like', "%$cleanPhone%");
         });
     }
 }

--- a/app/Rules/CannotDeleteOwnAccount.php
+++ b/app/Rules/CannotDeleteOwnAccount.php
@@ -15,9 +15,8 @@ class CannotDeleteOwnAccount implements Rule
 
     public function passes($attribute, $value)
     {
-        return !in_array(auth()->id(), $this->userIds);
+        return ! in_array(auth()->id(), $this->userIds);
     }
-
 
     public function message()
     {

--- a/app/Rules/CannotDeleteOwnAccount.php
+++ b/app/Rules/CannotDeleteOwnAccount.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+
+class CannotDeleteOwnAccount implements Rule
+{
+    private $userIds;
+
+    public function __construct($userIds)
+    {
+        $this->userIds = $userIds;
+    }
+
+    public function passes($attribute, $value)
+    {
+        return !in_array(auth()->id(), $this->userIds);
+    }
+
+
+    public function message()
+    {
+        return trans('UserDelete.cannot_delete_own_account');
+    }
+}

--- a/database/migrations/tenant/base/2022_07_19_015219_create_positions_users_table.php
+++ b/database/migrations/tenant/base/2022_07_19_015219_create_positions_users_table.php
@@ -4,7 +4,8 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class () extends Migration {
+return new class() extends Migration
+{
     /**
      * Run the migrations.
      *

--- a/database/seeders/tenants/PermissionTableSeeder.php
+++ b/database/seeders/tenants/PermissionTableSeeder.php
@@ -65,9 +65,9 @@ class PermissionTableSeeder extends Seeder
         /**
          * Permissões de Funções Específicas
          */
-        $roleAdmin[]      = Permission::updateOrCreate(['id' => 13], ['name' => 'view-role-admin']);
+        $roleAdmin[] = Permission::updateOrCreate(['id' => 13], ['name' => 'view-role-admin']);
         $roleTechnician[] = Permission::updateOrCreate(['id' => 14], ['name' => 'view-role-technician']);
-        $rolePlayer[]     = Permission::updateOrCreate(['id' => 15], ['name' => 'view-role-player']);
+        $rolePlayer[] = Permission::updateOrCreate(['id' => 15], ['name' => 'view-role-player']);
 
         /**
          * Permissões de Treinos

--- a/graphql/user/UserMutation.graphql
+++ b/graphql/user/UserMutation.graphql
@@ -33,5 +33,6 @@ extend type Mutation @guard {
     
     userDelete(id: [ID!]!): [User]
         @field(resolver: "UserMutation@delete")
+        @validator
         @can(ability: "delete")
 }

--- a/lang/en/UserDelete.php
+++ b/lang/en/UserDelete.php
@@ -1,0 +1,19 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Authentication Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used during authentication for various
+    | messages that we need to display to the user. You are free to modify
+    | these language lines according to your application's requirements.
+    |
+    */
+
+    'ids_required' => 'The users to be deleted are required.',
+    'ids_exists' => 'The users to be deleted do not exist.',
+    'cannot_delete_own_account' => 'You cannot delete your own account.',
+];

--- a/lang/pt-br/UserDelete.php
+++ b/lang/pt-br/UserDelete.php
@@ -1,0 +1,19 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Authentication Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used during authentication for various
+    | messages that we need to display to the user. You are free to modify
+    | these language lines according to your application's requirements.
+    |
+    */
+
+    'ids_required' => 'Os usuários a serem excluídos são obrigatórios.',
+    'ids_exists' => 'Os usuários a serem excluídos não existem.',
+    'cannot_delete_own_account' => 'Você não pode excluir sua própria conta.',
+];

--- a/tests/Feature/GraphQL/UserTest.php
+++ b/tests/Feature/GraphQL/UserTest.php
@@ -219,7 +219,7 @@ class UserTest extends TestCase
             $parameters['teamId'] = $team->id;
         }
 
-        if($parameters['name'] == null) {
+        if ($parameters['name'] == null) {
             $parameters['name'] = ' ';
         }
 
@@ -625,9 +625,9 @@ class UserTest extends TestCase
 
         $parameters['id'] = $user->id;
 
-        if($expectedMessage == 'UserEdit.email_is_valid') {
+        if ($expectedMessage == 'UserEdit.email_is_valid') {
             $parameters['email'] = 'notemail.com';
-        } elseif($expectedMessage != 'UserEdit.email_required') {
+        } elseif ($expectedMessage != 'UserEdit.email_required') {
             $parameters['email'] = $this->email;
         } else {
             $parameters['email'] = ' ';
@@ -635,8 +635,8 @@ class UserTest extends TestCase
 
         if ($expectedMessage == 'UserEdit.email_unique') {
             $userExist = User::factory()
-            ->has(Position::factory()->count(3))
-            ->create();
+                ->has(Position::factory()->count(3))
+                ->create();
 
             $parameters['email'] = $userExist->email;
         }
@@ -1013,11 +1013,11 @@ class UserTest extends TestCase
             $parameters['id'] = $data['error'];
         }
 
-        if($expectedMessage == 'UserDelete.cannot_delete_own_account') {
+        if ($expectedMessage == 'UserDelete.cannot_delete_own_account') {
             $parameters['id'] = $this->user->id;
         }
 
-        if($expectedMessage == 'UserDelete.ids_exists') {
+        if ($expectedMessage == 'UserDelete.ids_exists') {
             $parameters['id'] = User::max('id') + 1;
         }
 

--- a/tests/Feature/GraphQL/UserTest.php
+++ b/tests/Feature/GraphQL/UserTest.php
@@ -1013,6 +1013,10 @@ class UserTest extends TestCase
             $parameters['id'] = $data['error'];
         }
 
+        if($expectedMessage == 'UserDelete.cannot_delete_own_account') {
+            $parameters['id'] = $this->user->id;
+        }
+
         if($expectedMessage == 'UserDelete.ids_exists') {
             $parameters['id'] = User::max('id') + 1;
         }
@@ -1070,6 +1074,18 @@ class UserTest extends TestCase
                 ],
                 'type_message_error' => 'id',
                 'expected_message' => 'UserDelete.ids_exists',
+                'expected' => [
+                    'errors' => self::$errors,
+                    'data' => $userDelete,
+                ],
+                'hasPermission' => true,
+            ],
+            'delete user can not delete own account, expected error' => [
+                [
+                    'error' => 'this',
+                ],
+                'type_message_error' => 'id',
+                'expected_message' => 'UserDelete.cannot_delete_own_account',
                 'expected' => [
                     'errors' => self::$errors,
                     'data' => $userDelete,

--- a/tests/Feature/GraphQL/UserTest.php
+++ b/tests/Feature/GraphQL/UserTest.php
@@ -674,7 +674,7 @@ class UserTest extends TestCase
             'declare roleId is required, expected error' => [
                 [
                     'name' => $faker->name,
-                    
+
                     'password' => $password,
                     'positionId' => [1],
                     'teamId' => [1],
@@ -692,7 +692,7 @@ class UserTest extends TestCase
             'edit user with permission that shouldnt have, expected error' => [
                 [
                     'name' => $faker->name,
-                    
+
                     'password' => $password,
                     'positionId' => [1],
                     'teamId' => [1],
@@ -710,7 +710,7 @@ class UserTest extends TestCase
             'edit user without permission, expected error' => [
                 [
                     'name' => $faker->name,
-                    
+
                     'password' => $password,
                     'positionId' => [1],
                     'teamId' => [1],
@@ -785,7 +785,7 @@ class UserTest extends TestCase
             'edit user with team, success' => [
                 [
                     'name' => $faker->name,
-                    
+
                     'password' => $password,
                     'positionId' => [1],
                     'teamId' => [1],
@@ -805,7 +805,7 @@ class UserTest extends TestCase
             'edit user with position, success' => [
                 [
                     'name' => $faker->name,
-                    
+
                     'password' => $password,
                     'roleId' => [2],
                     'positionId' => [1],
@@ -825,7 +825,7 @@ class UserTest extends TestCase
             'edit user, success' => [
                 [
                     'name' => $faker->name,
-                    
+
                     'password' => $password,
                     'positionId' => [1],
                     'teamId' => [1],
@@ -844,7 +844,7 @@ class UserTest extends TestCase
             'edit user with 2 roles, success' => [
                 [
                     'name' => $faker->name,
-                    
+
                     'password' => $password,
                     'positionId' => [1],
                     'teamId' => [1],
@@ -863,7 +863,7 @@ class UserTest extends TestCase
             'text password less than 6 characters, expected error' => [
                 [
                     'name' => $faker->name,
-                    
+
                     'password' => '12345',
                     'positionId' => [1],
                     'teamId' => [1],
@@ -881,7 +881,7 @@ class UserTest extends TestCase
             'text password with 6 characters, success' => [
                 [
                     'name' => $faker->name,
-                    
+
                     'password' => $password,
                     'positionId' => [1],
                     'teamId' => [1],
@@ -918,7 +918,7 @@ class UserTest extends TestCase
                 [
                     'name' => ' ',
                     'password' => $password,
-                    
+
                     'positionId' => [1],
                     'teamId' => [1],
                     'roleId' => [2],
@@ -936,7 +936,7 @@ class UserTest extends TestCase
                 [
                     'name' => 'Th',
                     'password' => $password,
-                    
+
                     'positionId' => [1],
                     'teamId' => [1],
                     'roleId' => [2],
@@ -1013,6 +1013,10 @@ class UserTest extends TestCase
             $parameters['id'] = $data['error'];
         }
 
+        if($expectedMessage == 'UserDelete.ids_exists') {
+            $parameters['id'] = User::max('id') + 1;
+        }
+
         $response = $this->graphQL(
             'userDelete',
             $parameters,
@@ -1064,8 +1068,8 @@ class UserTest extends TestCase
                 [
                     'error' => 9999,
                 ],
-                'type_message_error' => 'message',
-                'expected_message' => 'internal',
+                'type_message_error' => 'id',
+                'expected_message' => 'UserDelete.ids_exists',
                 'expected' => [
                     'errors' => self::$errors,
                     'data' => $userDelete,

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -157,7 +157,7 @@ abstract class TestCase extends BaseTestCase
         $user->save();
 
         $this->email = $user->email;
-        
+
         $response = $this->graphQL(
             'login',
             [

--- a/tests/Unit/App/Models/UserTest.php
+++ b/tests/Unit/App/Models/UserTest.php
@@ -3,15 +3,12 @@
 namespace Tests\Unit\App\Models;
 
 use App\Models\User;
-use App\GraphQL\Mutations\UserMutation;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Support\Facades\Hash;
 use Spatie\Activitylog\LogOptions;
 use Spatie\Permission\Models\Permission;
-use Mockery\MockInterface;
-use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
 use Tests\TestCase;
 
 class UserTest extends TestCase


### PR DESCRIPTION
### O que?

* Adicionado validação para deletar usuários.
* Feito validação do Laravel Pint (PHP CS Fixer).
* Feito validação para pesquisa de itens como CPF, RG e Phone que podem conter caracteres especiais na pesquisa (que  estava fazendo com que alguns itens não fossem trazidos na pesquisa).
* Ajustados testes de ações dos usuários (deletar).

### Por quê?

* Um usuário não deve conseguir deletar a própria conta.
* Com estas alterações os testes precisavam de manutenção.
* Validação de pesquisa era essencial, pois alguns dados não estavam sendo trazidos

### Como?

* Criado nova validação que verifica se o usuário deletado é igual ao usuário que está fazendo a ação.
* Executado comando de validação do Laravel Pint
* Utilizado função que remove caracteres diferentes de numéricos para filtro.