### PR TITLE
Usuários: Adição de data nascimento no registro dos jogadores - VLC-118

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -72,7 +72,7 @@ class User extends Authenticatable implements HasApiTokensContract
             PermissionRegistrar::$pivotRole
         );
 
-        if (! PermissionRegistrar::$teams) {
+        if (!PermissionRegistrar::$teams) {
             return $relation;
         }
 
@@ -206,8 +206,16 @@ class User extends Authenticatable implements HasApiTokensContract
             $attributes['rg'] = $args['rg'];
         }
 
-        if (! empty($attributes)) {
-            if (! $this->information) {
+        if (isset($args['birthDate'])) {
+            $attributes['birth_date'] = $args['birthDate'];
+        }
+
+        if (isset($args['birth_date'])) {
+            $attributes['birth_date'] = $args['birth_date'];
+        }
+
+        if (!empty($attributes)) {
+            if (!$this->information) {
                 $this->information = $this->information()->create($attributes);
             } else {
                 $this->information->fill($attributes);
@@ -308,7 +316,7 @@ class User extends Authenticatable implements HasApiTokensContract
         $query->when(
             isset($args['filter']) &&
             isset($args['filter']['positionsIds']) &&
-            ! empty($args['filter']['positionsIds']),
+            !empty($args['filter']['positionsIds']),
             function ($query) use ($args) {
                 $query->whereHas('positions', function ($query) use ($args) {
                     $query->filterIds($args['filter']['positionsIds']);
@@ -322,7 +330,7 @@ class User extends Authenticatable implements HasApiTokensContract
         $query->when(
             isset($args['filter']) &&
             isset($args['filter']['teamsIds']) &&
-            ! empty($args['filter']['teamsIds']),
+            !empty($args['filter']['teamsIds']),
             function ($query) use ($args) {
                 $query->whereHas('teams', function ($query) use ($args) {
                     $query->filterIds($args['filter']['teamsIds']);

--- a/app/Models/UserInformation.php
+++ b/app/Models/UserInformation.php
@@ -16,6 +16,7 @@ class UserInformation extends Model
         'cpf',
         'phone',
         'rg',
+        'birth_date',
     ];
 
     public function user()

--- a/database/factories/UserInformationFactory.php
+++ b/database/factories/UserInformationFactory.php
@@ -20,6 +20,7 @@ class UserInformationFactory extends Factory
             'cpf' => $this->faker->numberBetween(10000000000, 99999999999),
             'rg' => $this->faker->numberBetween(100000000, 999999999),
             'phone' => $this->faker->phoneNumber(),
+            'birth_date' => $this->faker->date(),
         ];
     }
 }

--- a/database/migrations/tenant/base/2014_10_12_010000_create_users_informations_table.php
+++ b/database/migrations/tenant/base/2014_10_12_010000_create_users_informations_table.php
@@ -19,6 +19,7 @@ class CreateUsersInformationsTable extends Migration
             $table->string('cpf')->nullable();
             $table->string('phone')->nullable();
             $table->string('rg')->nullable();
+            $table->date('birth_date')->nullable();
             $table->timestamps();
             $table->softDeletes();
 

--- a/graphql/training/TrainingType.graphql
+++ b/graphql/training/TrainingType.graphql
@@ -27,10 +27,10 @@ type Training {
     status: Boolean
 
     "Training dateStart. Must contain a date greater than dateEnd. Is required. A datetime string with format `Y-m-d H:i:s`, e.g. `2018-05-23 13:43:32`."
-    dateStart: String @rename(attribute: "date_start")
+    dateStart: DateTime @rename(attribute: "date_start")
 
     "Training dateEnd. Must contain a date less than dateStart. Is required. A datetime string with format `Y-m-d H:i:s`, e.g. `2018-05-23 13:43:32`."
-    dateEnd: String @rename(attribute: "date_end")
+    dateEnd: DateTime @rename(attribute: "date_end")
 
     "Training description."
     description: String

--- a/graphql/user/UserInformationType.graphql
+++ b/graphql/user/UserInformationType.graphql
@@ -4,7 +4,7 @@ type UserInformation {
     id: ID!
 
     "User ID."
-    user_id: Int!
+    userId: Int! @rename(attribute: "user_id")
 
     "User relation."
     user: User @belongsTo(relation: "user")
@@ -17,6 +17,9 @@ type UserInformation {
 
     "Phone number."
     phone: String
+
+    "Birth date. A date string with format `Y-m-d`, e.g. `2018-05-23`."
+    birthDate: Date @rename(attribute: "birth_date")
 
     "Date created. A datetime string with format `Y-m-d H:i:s`, e.g. `2018-05-23 13:43:32`."
     createdAt: DateTime! @rename(attribute: "created_at")

--- a/graphql/user/UserMutation.graphql
+++ b/graphql/user/UserMutation.graphql
@@ -6,6 +6,7 @@ extend type Mutation @guard {
         cpf: String
         rg: String
         phone: String
+        birthDate: String
         roleId: [Int!]!
         positionId: [Int]
         teamId: [Int]
@@ -22,6 +23,7 @@ extend type Mutation @guard {
         cpf: String
         rg: String
         phone: String
+        birthDate: String
         roleId: [Int!]!
         positionId: [Int]
         teamId: [Int]

--- a/tests/Feature/GraphQL/UserTest.php
+++ b/tests/Feature/GraphQL/UserTest.php
@@ -392,6 +392,26 @@ class UserTest extends TestCase
                 'hasTeam' => false,
                 'hasPermission' => true,
             ],
+            'create user with birth date, success' => [
+                [
+                    'name' => $faker->name,
+                    'email' => $faker->email,
+                    'positionId' => [1],
+                    'teamId' => [1],
+                    'roleId' => [3],
+                    'password' => $password,
+                    'birthDate' => $faker->date(),
+                ],
+                'type_message_error' => false,
+                'expected_message' => false,
+                'expected' => [
+                    'data' => [
+                        'userCreate' => self::$data,
+                    ],
+                ],
+                'hasTeam' => false,
+                'hasPermission' => true,
+            ],
             'create user with 2 roles, success' => [
                 [
                     'name' => $faker->name,
@@ -840,6 +860,26 @@ class UserTest extends TestCase
                     'name' => $faker->name,
 
                     'password' => $password,
+                    'positionId' => [1],
+                    'teamId' => [1],
+                    'roleId' => [2],
+                ],
+                'type_message_error' => false,
+                'expected_message' => false,
+                'expected' => [
+                    'data' => [
+                        'userEdit' => self::$data,
+                    ],
+                ],
+                'hasTeam' => false,
+                'hasPermission' => true,
+            ],
+            'edit user with birth date, success' => [
+                [
+                    'name' => $faker->name,
+
+                    'password' => $password,
+                    'birthDate' => $faker->date(),
                     'positionId' => [1],
                     'teamId' => [1],
                     'roleId' => [2],


### PR DESCRIPTION
### O que?

Adicionar a data de nascimento para o registro dos jogadores.

### Por quê?

Necessário para saber a idade dos jogadores, alguns casos de uso apotam que alguns campeonatos podem ter limite de idade, servirá para fazer essa validação no futuro, e também para mostrar em tela.

### Como?

Adicionado campo `birth_date` para marcar a data de aniversário, salvando na tabela `user_information`.

