### PR TITLE
Testes: Adicionado dinamismo para estruturas de dados que sejam testadas - VLC-130

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -85,7 +85,7 @@ abstract class TestCase extends BaseTestCase
 
         Artisan::call('migrate --seed');
 
-        if (! Tenant::find($tenantId)) {
+        if (!Tenant::find($tenantId)) {
             $tenant = Tenant::create(['id' => $tenantId]);
             Tenant::create(['id' => $tenantIdLogs]);
             $tenant->domains()->create(['domain' => $tenantId . '.' . env('APP_HOST')]);
@@ -223,28 +223,25 @@ abstract class TestCase extends BaseTestCase
         $query .= "{$inputClose}{$closeOpen}";
 
         foreach ($dadosSaida as $key => $value) {
-            if (is_array($value)) {
-                $total = count($value);
-                $count = 0;
-
-                foreach ($value as $newValue) {
-                    if ($count == 0) {
-                        $query .= " $key {";
-                    }
-                    $query .= " $newValue";
-                    $count++;
-                    if ($count == $total) {
-                        $query .= '}';
-                    }
-                }
-            } else {
-                $query .= " $value ";
-            }
+            $query .= $this->converteDadosSaidaGraphQL($key, $value);
         }
 
         $query .= "{$closeExit}";
 
         return $query;
+    }
+
+    private function converteDadosSaidaGraphQL($key, $value): string
+    {
+        if (is_array($value)) {
+            $queryPart = " $key {";
+            foreach ($value as $subKey => $subValue) {
+                $queryPart .= $this->converteDadosSaidaGraphQL($subKey, $subValue);
+            }
+            $queryPart .= ' }';
+            return $queryPart;
+        }
+        return " $value ";
     }
 
     private function converteDadosArrayEntrada(string $key, array $value): string
@@ -334,7 +331,7 @@ abstract class TestCase extends BaseTestCase
     public function assertMessageError($type_message_error, $response, bool $permission, $expected_message)
     {
         if ($type_message_error) {
-            if (! $permission) {
+            if (!$permission) {
                 $this->assertSame($response->json()['errors'][0][$type_message_error], $expected_message);
             } else {
                 if (isset($response->json()['errors'][0]['extensions'])) {


### PR DESCRIPTION
### O que?

Adicionado função recursiva.

### Por quê?

Adicionado função para gerar dinamismo nos objetos passados como parâmetro nos testes.

### Como?

Dentro da classe testcase foi modificado o método que faz a montagem da string que faz a consulta no GraphQL
