### PR TITLE
fix(treino): ajustado edição de treino, ao fazer a edição de um time - VLT-149

### DIFF
--- a/app/Models/Training.php
+++ b/app/Models/Training.php
@@ -191,6 +191,14 @@ class Training extends Model
         $this->sendNotificationTechnicians($daysNotification);
     }
 
+    public function deleteConfirmationsPlayersOld(int $teamId)
+    {
+        $this->confirmationsTraining()
+            ->where('team_id', $teamId)
+            ->where('training_id', $this->id)
+            ->delete();
+    }
+
     /**
      * @codeCoverageIgnore
      *

--- a/app/Observers/TrainingObserver.php
+++ b/app/Observers/TrainingObserver.php
@@ -31,6 +31,11 @@ class TrainingObserver
      */
     public function updated(Training $training)
     {
+        if ($training->isDirty('team_id')) {
+            $originalTeamId = $training->getOriginal('team_id');
+            $training->deleteConfirmationsPlayersOld($originalTeamId);
+        }
+
         $training->confirmationsPlayers($training->id);
 
         if ($training->getOriginal('status') && $training->status == 0) {


### PR DESCRIPTION
### O que?

Existia um bug, onde ao editar um time de um treino, os jogadores relacionados anteriormente se permaneciam, o que estaria incorreto, já que não fazem parte do time selecionado para o treino.

### Como?

Foi adicionado ao observer, antes de fazer a notificação para os jogadores do treino uma validação, que se o time for alterado chama uma função que deleta os registros de confirmações de treino dos jogadores selecionados anteriormente.

