### PR TITLE
test(usuário): remover caso de uso de testes de usuário para sempre atualizar a senha - VLT-151

### DIFF
--- a/tests/Feature/GraphQL/UserTest.php
+++ b/tests/Feature/GraphQL/UserTest.php
@@ -484,24 +484,6 @@ class UserTest extends TestCase
                 'hasTeam' => false,
                 'hasPermission' => true,
             ],
-            'no text password, expected error' => [
-                [
-                    'name' => $faker->name,
-                    'password' => ' ',
-                    'email' => $faker->email,
-                    'positionId' => [1],
-                    'teamId' => [1],
-                    'roleId' => [2],
-                ],
-                'type_message_error' => 'password',
-                'expected_message' => 'UserCreate.password_required',
-                'expected' => [
-                    'errors' => self::$errors,
-                    'data' => $userCreate,
-                ],
-                'hasTeam' => false,
-                'hasPermission' => true,
-            ],
             'text password with 6 characters, success' => [
                 [
                     'name' => $faker->name,


### PR DESCRIPTION
### O que?

Ao fazer uma edição de usuário, essa opção não deveria existir, pois, não necessariamente ao editar uma informação dele será necessário fazer a troca da senha, este campo é enviado com a opção sometimes (as vezes)

### Por quê?

Nem sempre é necessário editar a senha do usuário, a validação do erro estava sendo feita incorretamente.

### Como?

Apenas removido caso de testes
