### PR TITLE
feat(treino): adicionando métricas na visualização de confirmação de treinos - VLT-150

### DIFF
--- a/app/Models/Training.php
+++ b/app/Models/Training.php
@@ -235,6 +235,8 @@ class Training extends Model
             'rejectedPercentage' => $rejected > 0 ? ($rejected / ($total) * 100) : 0,
             'presence' => $presence,
             'absence' => $absence,
+            'presencePercentage' => $presence > 0 ? ($presence / ($total) * 100) : 0,
+            'absencePercentage' => $absence > 0 ? ($absence / ($total) * 100) : 0,
         ];
     }
 

--- a/app/Models/Training.php
+++ b/app/Models/Training.php
@@ -221,6 +221,8 @@ class Training extends Model
         $confirmed = $this->confirmationsTraining()->status('confirmed')->count() ?? 0;
         $pending = $this->confirmationsTraining()->status('pending')->count() ?? 0;
         $rejected = $this->confirmationsTraining()->status('rejected')->count() ?? 0;
+        $presence = $this->confirmationsTraining()->presence(true)->count() ?? 0;
+        $absence = $this->confirmationsTraining()->presence(false)->count() ?? 0;
         $total = $confirmed + $pending + $rejected;
 
         return [
@@ -231,6 +233,8 @@ class Training extends Model
             'confirmedPercentage' => $confirmed > 0 ? ($confirmed / ($total) * 100) : 0,
             'pendingPercentage' => $pending > 0 ? ($pending / ($total) * 100) : 0,
             'rejectedPercentage' => $rejected > 0 ? ($rejected / ($total) * 100) : 0,
+            'presence' => $presence,
+            'absence' => $absence,
         ];
     }
 

--- a/graphql/confirmation-training/ConfirmationTrainingMetricsType.graphql
+++ b/graphql/confirmation-training/ConfirmationTrainingMetricsType.graphql
@@ -6,11 +6,16 @@ type ConfirmationTrainingMetrics {
     pending: Int!
     "The number of trainings that were rejected"
     rejected: Int!
-
+    "Total number of players"
+    total: Int!
     "The number of trainings that were confirmed in percentage"
     confirmedPercentage: Float!
     "The number of trainings that were pending in percentage"
     pendingPercentage: Float!
     "The number of trainings that were rejected in percentage"
     rejectedPercentage: Float!
+    "The number of presences"
+    presence: Int!
+    "The number of absences"
+    absence: Int!
 }

--- a/graphql/confirmation-training/ConfirmationTrainingMetricsType.graphql
+++ b/graphql/confirmation-training/ConfirmationTrainingMetricsType.graphql
@@ -18,4 +18,10 @@ type ConfirmationTrainingMetrics {
     presence: Int!
     "The number of absences"
     absence: Int!
+
+    "The number of presences in percentage"
+    presencePercentage: Float!
+
+    "The number of absences in percentage"
+    absencePercentage: Float!
 }

--- a/graphql/training/TrainingType.graphql
+++ b/graphql/training/TrainingType.graphql
@@ -27,7 +27,7 @@ type Training {
     "Confirmations Training relation."
     confirmationsTraining: [ConfirmationTraining] @hasMany
 
-    "Metrics for confirming intention to go to training."
+    "Metrics to confirm the intention to attend training and attendance metrics."
     confirmationTrainingMetrics: ConfirmationTrainingMetrics @field(resolver: "App\\GraphQL\\Queries\\ConfirmationTrainingQuery@metrics")
 
     "Training status. Active(true) or Canceled(false)."

--- a/graphql/training/TrainingType.graphql
+++ b/graphql/training/TrainingType.graphql
@@ -27,6 +27,7 @@ type Training {
     "Confirmations Training relation."
     confirmationsTraining: [ConfirmationTraining] @hasMany
 
+    "Metrics for confirming intention to go to training."
     confirmationTrainingMetrics: ConfirmationTrainingMetrics @field(resolver: "App\\GraphQL\\Queries\\ConfirmationTrainingQuery@metrics")
 
     "Training status. Active(true) or Canceled(false)."


### PR DESCRIPTION
### O que?

Adicionado parâmetros de métricas para presença.

### Por quê?

Estavam sendo calculados apenas métricas de intenção de presença, e as métricas de presença do treino não tinham sido desenvolvidas.

### Como?

Adicionado novas métricas fazendo os devidos cálculos por consulta, o próprio banco já havia sido projetado para conseguir extrair essas informações.

